### PR TITLE
Prevent filereader from missing one byte per chunk

### DIFF
--- a/raftinc/fileio.tcc
+++ b/raftinc/fileio.tcc
@@ -149,7 +149,7 @@ public:
             auto &chunk( port.template allocate< chunktype  >() );
             if( init )
             {
-               fseek( fp, -( chunk_offset - 1) , SEEK_CUR );
+               fseek( fp, - chunk_offset , SEEK_CUR );
             }
             else
             {


### PR DESCRIPTION
I don't exactly know what is intended by seeking with chunkoffset in the filereader, but the behaviour prior to this change is that the filereader misses one byte of data per chunk.

This cannot be correct, and this pullrequest fixes that.

If the new behaviour is wrong, please let me know and I can submit a PR instead.