### PR TITLE
Fixing compilation on Windows/MSVC++ 14.24 (Visual Studio 16.4.3)

### DIFF
--- a/cmake/CheckGitDep.cmake
+++ b/cmake/CheckGitDep.cmake
@@ -5,7 +5,11 @@ set( DEPDIR ${CMAKE_SOURCE_DIR}/git-dep )
 ##
 # LIST MODULES HERE
 ##
-set( GIT_MODULES cmdargs shm )
+if(WIN32)
+ set( GIT_MODULES cmdargs )
+else()
+ set( GIT_MODULES cmdargs shm )
+endif()
 ##
 # NOW CHECK THEM OUT 
 ##

--- a/raftinc/alloc_traits.tcc
+++ b/raftinc/alloc_traits.tcc
@@ -17,10 +17,19 @@
 
 //FIXME, add std::move for int_allocate obj
 #ifndef L1D_CACHE_LINE_SIZE
+
+#ifdef _MSC_VER
+#define STRINGIZE_HELPER(x) #x
+#define STRINGIZE(x) STRINGIZE_HELPER(x)
+#define WARNING(desc) message(__FILE__ "(" STRINGIZE(__LINE__) ") : Warning: " #desc)
+#pragma WARNING(Using 64 bytes as default cache line size, to fix recompile with -DL1D_CACHE_LINE_SIZE=XXX)
+#else
 #warning "Using 64 bytes as default cache line size, to fix recompile with -DL1D_CACHE_LINE_SIZE=XXX"
-#define L1D_CACHE_LINE_SIZE 64
 #endif
 
+#define L1D_CACHE_LINE_SIZE 64
+
+#endif
 /**
  * see if the given class/type fits within a single cache line
  */

--- a/raftinc/fifo.hpp
+++ b/raftinc/fifo.hpp
@@ -182,7 +182,11 @@ public:
       void *ptr( nullptr );
       /** call blocks till an element is available **/
       local_allocate( &ptr );
-      T * __attribute__((__unused__)) temp( 
+#ifdef _MSC_VER // MSVC does not support __attribute__
+      T * temp(
+#else
+      T* __attribute__((__unused__)) temp(
+#endif
          new (ptr) T( std::forward< Args >( params )... ) );
       UNUSED( temp );
       return( autorelease< T, allocatetype >( 

--- a/testsuite/nonTrivialAllocatorPopExternal.cpp
+++ b/testsuite/nonTrivialAllocatorPopExternal.cpp
@@ -5,8 +5,10 @@
 #include <raft>
 #include <raftio>
 #include <limits>
-#include <unistd.h>
 
+#ifdef __unix__
+#include <unistd.h>
+#endif
 
 static bool global_bool = false;
 


### PR DESCRIPTION
Hi Jonathan, 

this pull request aims to fix compilation using Visual Studio 2019 on Windows 10. 

What I've done:

- exclude shm on Windows
- conditionally compile __attribute__ when not compiling with msvc  (fixes #70, although the suggested fix there may be a better solution)
- conditionally include unix headers
- emulate #warning when compiling with msvc  (fixes #69)

Currently, the `nonTrivialAllocatorPopExternal` test fails most likely due to improper alignment as the  build warning `C4316: Object allocated on the heap may not be aligned for this type.` suggests. Do you have any guidance on how to fix this?

Also, cache line detection does not work, thus raft falls back to the default cache line size of 64. The compiler warning issued by this now compiles as expected

I've not tested compilation on Unix though, but I think building on travis is part of the pull request validation, right?

Best,
Florian