### PR TITLE
simplify port iterator

### DIFF
--- a/raftinc/portiterator.hpp
+++ b/raftinc/portiterator.hpp
@@ -21,8 +21,6 @@
 #define _PORTITERATOR_HPP_  1
 #include <iterator>
 #include <map>
-#include <thread>
-#include <mutex>
 #include <cstddef>
 
 #include "portmap_t.hpp"
@@ -32,32 +30,22 @@ class FIFO;
 class PortIterator : public std::iterator< std::forward_iterator_tag, FIFO >
 {
 public:
-   PortIterator( portmap_t * const port_map );
+   explicit PortIterator( portmap_t * port_map );
    
-   PortIterator( portmap_t * const port_map, const std::size_t index );
-
-   PortIterator( const PortIterator &it );
-
-   virtual ~PortIterator();
+   PortIterator( portmap_t * port_map, std::size_t index );
 
    PortIterator& operator++() ;
    
-   bool operator==(const PortIterator& rhs) ; 
-   bool operator!=(const PortIterator& rhs) ;
-   FIFO& operator*() ;
-
-
-   const std::string& name();
+   bool operator==(const PortIterator& rhs) const; 
+   bool operator!=(const PortIterator& rhs) const;
+   FIFO& operator*() const;
+   
+   const std::string& name() const;
 
 private:
-   static inline
-   void initKeyMap( portmap_t * const port_map, 
-                    std::vector< std::string > &key_map ) ;
-   
-   portmap_t * const               port_map;
-   std::vector< std::string >      key_map;
-   std::size_t                     map_index = 0;
-   bool                            is_end       = false;
+   using map_iterator_type = std::decay_t<decltype(begin(portmap_t::map))>;
+
+   map_iterator_type map_iterator;
 };
 
 #endif /* END _PORTITERATOR_HPP_ */

--- a/src/portiterator.cpp
+++ b/src/portiterator.cpp
@@ -17,87 +17,52 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <algorithm>
 #include <utility>
-#include <map>
-#include <iostream>
 #include "port_info.hpp"
 #include "portmap_t.hpp"
 #include "portiterator.hpp"
 
-PortIterator::PortIterator( portmap_t * const port_map ) : port_map( port_map )
+PortIterator::PortIterator( portmap_t * const port_map )
+	: map_iterator(port_map->map.begin())
 {
-   PortIterator::initKeyMap( port_map, key_map );
-   //pthread_mutex_lock_d( &(port_map->mutex_map), __FILE__, __LINE__ ); 
+
 }
 
 PortIterator::PortIterator( portmap_t * const port_map, 
-                            const std::size_t index ) : 
-                                                    port_map( port_map ),
-                                                    map_index( index )
+                            const std::size_t index )
+	: map_iterator(index == port_map->map.size() 
+        ? port_map->map.end()
+        : std::next(port_map->map.begin(), index) )
 {
-   is_end = true;
-   PortIterator::initKeyMap( port_map, key_map );
-}
-
-PortIterator::PortIterator( const PortIterator &it ) : port_map( it.port_map ),
-                                                       map_index( it.map_index )
-{
-   PortIterator::initKeyMap( port_map, key_map );
-}
-
-PortIterator::~PortIterator()
-{
-   if( is_end )
-   {
-     // pthread_mutex_unlock( &(port_map->mutex_map) );
-   }
 }
 
 PortIterator&
 PortIterator::operator++() 
 {
-   map_index++;
+  ++map_iterator;
    return( (*this) );
 }
 
 const std::string&
-PortIterator::name()
+PortIterator::name() const
 {
-    return( key_map[ map_index ] );
+    return( map_iterator->first );
 }
 
 bool
-PortIterator::operator==( const PortIterator &rhs ) 
+PortIterator::operator==( const PortIterator &rhs ) const
 {
-   /** 
-    * TODO, on a more philosophical note, should this
-    * be a ptr comparison for the FIFO's but then the 
-    * end function would be harder to implement
-    */
-   return( map_index == rhs.map_index );
+   return( map_iterator == rhs.map_iterator );
 }
 
 bool 
-PortIterator::operator!=( const PortIterator &rhs ) 
+PortIterator::operator!=( const PortIterator &rhs ) const
 {
-   return( map_index != rhs.map_index );
+   return( map_iterator != rhs.map_iterator );
 }
 
 FIFO&
-PortIterator::operator*() 
+PortIterator::operator*() const
 { 
-   return(
-      (*port_map->map[ key_map[ map_index ] ].getFIFO() ) );
-}
-
-void
-PortIterator::initKeyMap( portmap_t * const port_map, 
-                          std::vector< std::string > &key_map ) 
-{
-   std::map< std::string, PortInfo > &map_ref( port_map->map );
-   for( const auto &pair : map_ref )
-   {
-      key_map.emplace_back( pair.first );
-   }
+   return(*map_iterator->second.getFIFO());
 }


### PR DESCRIPTION
Hi,

while profiling I noticed that the port iterator was burning suprisingly many cpu cycles. Looking at the implementation I found that the key map was causing troubles as it allocated on the heap. Also, in my opinion, the way the iterator was implemented seemed more complicated than it needed to be. 

So I simplified it by

- removing the key map
- removing the map ptr
- using the corresponding map iterator
- use map.end() when index == map.size() to avoid linearly iterating to the end using std::next

Note that these changes do not alter the public interface of PortIterator. However, by changing the constructor to take the map iterator directly, the implementation could be streamlined even further . 