### PR TITLE
finished back-porting parser-improvement changes, need to check win64…

### DIFF
--- a/raftinc/alloc_defs.hpp
+++ b/raftinc/alloc_defs.hpp
@@ -5,9 +5,9 @@
  * are only a few choices, but that could likely change.
  *
  * @author: Jonathan Beard
- * @version: Tue Aug 16 19:47:01 2016
+ * @version: 25 May 2020
  * 
- * Copyright 2016 Jonathan Beard
+ * Copyright 2020 Jonathan Beard
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,6 @@
 #ifndef RAFTALLOC_DEFS_HPP
 #define RAFTALLOC_DEFS_HPP  1
 
-enum memory_type : std::uint8_t { heap, SHM };
+enum memory_type : std::uint8_t { heap, shm };
 
 #endif /* END RAFTALLOC_DEFS_HPP */

--- a/raftinc/allocate.hpp
+++ b/raftinc/allocate.hpp
@@ -31,8 +31,19 @@
 #include "fifo.hpp"
 #include <set>
 
-#define ALLOC_ALIGN_WIDTH   L1D_CACHE_LINE_SIZE
-#define INITIAL_ALLOC_SIZE  64
+/**
+ * ALLOC_ALIGN_WIDTH - in previous versions we'd align based
+ * on perceived vector width, however, there's more benefit
+ * in aligning to cache line sizes. 
+ */
+
+#if defined __AVX__ || __AVX2__ || _WIN64
+#define ALLOC_ALIGN_WIDTH L1D_CACHE_LINE_SIZE
+#else
+#define ALLOC_ALIGN_WIDTH L1D_CACHE_LINE_SIZE
+#endif
+
+#define INITIAL_ALLOC_SIZE 64
 
 namespace raft
 {

--- a/raftinc/blocked.hpp
+++ b/raftinc/blocked.hpp
@@ -3,7 +3,7 @@
  * @author: Jonathan Beard
  * @version: Sun Jun 29 14:06:10 2014
  *
- * Copyright 2014 Jonathan Beard
+ * Copyright 2020 Jonathan Beard
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,31 +21,41 @@
 #define RAFTBLOCKED_HPP  1
 #include <cstdint>
 #include <cassert>
+#include "defs.hpp"
 #include "internaldefs.hpp"
+
 
 struct ALIGN( L1D_CACHE_LINE_SIZE ) Blocked
 {
+    /** 
+     * this is really the backign store for the number of 
+     * times any queue in the system is blocked. Likely
+     * this is plenty of storage given the purpose and 
+     * no deleterious impact if we just wrap....
+     */
     using value_type = std::uint32_t;
     using whole_type = std::uint64_t;
     
     static_assert( sizeof( value_type ) * 2 == sizeof( whole_type ),
                    "Error, the whole type must be double the size of the half type" );
-    Blocked() = default;
+    
+    Blocked();
 
-    Blocked( const Blocked &other ) : all( other.all ){}
+    Blocked( const Blocked &other );
 
-    Blocked& operator += ( const Blocked &rhs )
+    constexpr Blocked& operator = ( const Blocked &other ) noexcept
     {
-       if( ! rhs.bec.blocked )
-       {
-          (this)->bec.count += rhs.bec.count;
-       }
-       return( *this );
+        /** again, simple integer, let's ignore the case of other == this **/
+        (this)->all = other.all;
+        return( *this );
     }
+
+    Blocked& operator += ( const Blocked &rhs ) noexcept;
+    
     struct blocked_and_counter
     {
-       value_type   blocked;
-       value_type    count;
+       value_type   blocked = 0;
+       value_type   count   = 0;
     };
     
     union

--- a/raftinc/bufferdata.tcc
+++ b/raftinc/bufferdata.tcc
@@ -29,6 +29,7 @@
 #include <type_traits>
 #if defined __APPLE__ || defined __linux
 #include <sys/mman.h>
+#include <shm>
 #endif
 #include "signalvars.hpp"
 #include "pointer.hpp"
@@ -38,7 +39,7 @@
 
 #include "alloc_traits.tcc"
 #include "defs.hpp"
-#include <shm>
+
 
 namespace Buffer
 {
@@ -325,6 +326,8 @@ template < class T >
 }; /** end heap > Line Size **/
 
 
+#if defined __APPLE__ || defined __linux
+
 template < class T > struct Data< T, Type::SharedMemory > : 
    public DataBase< T > 
 {
@@ -506,7 +509,7 @@ template < class T > struct Data< T, Type::SharedMemory > :
    const std::string ptr_key; 
    const Direction   dir;
 };
-
+#endif
 
 } //end namespace Buffer
 #endif /* END RAFTBUFFERDATA_TCC */

--- a/raftinc/bufferdata.tcc
+++ b/raftinc/bufferdata.tcc
@@ -3,7 +3,7 @@
  * @author: Jonathan Beard
  * @version: Fri May 16 13:08:25 2014
  * 
- * Copyright 2014 Jonathan Beard
+ * Copyright 2020 Jonathan Beard
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef BUFFERDATA_TCC
-#define BUFFERDATA_TCC  1
+#ifndef RAFTBUFFERDATA_TCC
+#define RAFTBUFFERDATA_TCC  1
 #include <cstdint>
 #include <cstddef>
 #include <cstring>
@@ -37,13 +37,13 @@
 #include "database.tcc"
 
 #include "alloc_traits.tcc"
-
-#if BUILDSHM
-#include "shm.hpp"
-#endif
+#include "defs.hpp"
+#include <shm>
 
 namespace Buffer
 {
+
+
 
 template < class T,
            Type::RingBufferType B,
@@ -60,23 +60,27 @@ template < class T > struct Data< T,
          const std::size_t max_cap,
          const std::size_t start_position ) : DataBase< T >( max_cap )
    {
-      assert( ptr != nullptr );
-      (this)->store  = ptr;
-      (this)->signal = (Signal*)       calloc( 1,
-                                               sizeof( Signal ) );
-      if( (this)->signal == nullptr )
-      {
-         perror( "Failed to allocate signal queue!" );
-         exit( EXIT_FAILURE );
-      }
-      /** set index to be start_position **/
-      (this)->signal[ 0 ].index  = start_position; 
-      /** allocate read and write pointers **/
-      (this)->read_pt   = new Pointer( max_cap );
-      (this)->write_pt  = new Pointer( max_cap, 1 ); 
-      
-      (this)->external_alloc = true;
+        assert( ptr != nullptr );
+        (this)->store  = ptr;
+        (this)->signal = (Signal*)       calloc( 1,
+                                                 sizeof( Signal ) );
+        if( (this)->signal == nullptr )
+        {
+           perror( "Failed to allocate signal queue!" );
+           exit( EXIT_FAILURE );
+        }
+        
+        /** set index to be start_position **/
+        (this)->signal[ 0 ].index  = start_position; 
+
+        /** allocate read and write pointers **/
+        new ( &(this)->read_pt ) Pointer( max_cap );
+        new ( &(this)->write_pt) Pointer( max_cap, 1 ); 
+        new ( &(this)->read_stats ) Blocked();
+        new ( &(this)->write_stats ) Blocked();
+        (this)->external_alloc = true;
    }
+
 
 
    Data( const std::size_t max_cap , 
@@ -96,7 +100,7 @@ template < class T > struct Data< T,
       }
 #elif (defined _WIN64 ) || (defined _WIN32) 
 //FIXME, we need to test this on Win sys before making live    
-      (this)->store = reinterpret_cast< T* >(  _aligned_malloc( (this)->length_store,align) );
+      (this)->store = reinterpret_cast< T* >(  _aligned_malloc( (this)->length_store ) );
 #else
       /** 
        * would use the array allocate, but well...we'd have to 
@@ -104,8 +108,8 @@ template < class T > struct Data< T,
        */
       (this)->store = reinterpret_cast< T* >( malloc( (this)->length_store ) );
 #endif
+      //FIXME - this should be an exception 
       assert( (this)->store != nullptr );
-      
 #if (defined __linux ) || (defined __APPLE__ )
       posix_madvise( (this)->store, 
                      (this)->length_store,  
@@ -115,13 +119,16 @@ template < class T > struct Data< T,
                                                sizeof( Signal ) );
       if( (this)->signal == nullptr )
       {
+         //FIXME - this should be an exception too
          perror( "Failed to allocate signal queue!" );
          exit( EXIT_FAILURE );
       }
       /** allocate read and write pointers **/
       /** TODO, see if there are optimizations to be made with sizing and alignment **/
-      (this)->read_pt   = new Pointer( max_cap );
-      (this)->write_pt  = new Pointer( max_cap ); 
+      new ( &(this)->read_pt ) Pointer( max_cap );
+      new ( &(this)->write_pt ) Pointer( max_cap ); 
+      new ( &(this)->read_stats ) Blocked();
+      new ( &(this)->write_stats ) Blocked();
    }
   
    /**
@@ -134,43 +141,47 @@ template < class T > struct Data< T,
     */
    virtual void copyFrom( DataBase< T > *other )
    {
-      //TODO, figure something better out for here 
-      if( other->external_alloc )
-      {
-         assert( false );
-      }
-      delete( (this)->read_pt );
-      (this)->read_pt = new Pointer( (other->read_pt),   (this)->max_cap );
-      delete( (this)->write_pt );
-      (this)->write_pt = new Pointer( (other->write_pt), (this)->max_cap );
+        if( other->external_alloc )
+        {
+            //FIXME: throw rafterror that is synchronized
+            std::cerr 
+                << "FATAL: Attempting to resize a FIFO that is statically alloc'd\n";
+            exit( EXIT_FAILURE );
+        }
+        
+        void *ptr( nullptr );
+        ptr = new ( &(this)->read_pt ) Pointer( (other->read_pt),   (this)->max_cap );
+        ptr = new ( &(this)->write_pt ) Pointer( (other->write_pt), (this)->max_cap );
+        UNUSED( ptr );
+        (this)->is_valid = other->is_valid;
 
-      (this)->src_kernel = other->src_kernel;
-      (this)->dst_kernel = other->dst_kernel;
-      
-      (this)->is_valid = other->is_valid;
-
-      /** buffer is already alloc'd, copy **/
-      std::memcpy( (void*)(this)->store /* dst */,
-                   (void*)other->store  /* src */,
-                   other->length_store );
-      /** copy signal buff **/
-      std::memcpy( (void*)(this)->signal /* dst */,
-                   (void*)other->signal  /* src */,
-                   other->length_signal );
-      /** everything should be put back together now **/
+        /** buffer is already alloc'd, copy **/
+        std::memcpy( (void*)(this)->store /* dst */,
+                     (void*)other->store  /* src */,
+                     other->length_store );
+        
+        /** copy signal buff **/
+        std::memcpy( (void*)(this)->signal /* dst */,
+                     (void*)other->signal  /* src */,
+                     other->length_signal );
+        /** stats objects are still valid, copy the ptrs over **/
+        
+        (this)->read_stats  = other->read_stats; 
+        (this)->write_stats = other->write_stats;
+        /** since we might use this as a min size, make persistent **/
+        (this)->force_resize = other->force_resize;
+        /** everything should be put back together now **/
+        (this)->thread_access[ 0 ] = other->thread_access[ 0 ]; 
+        (this)->thread_access[ 1 ] = other->thread_access[ 1 ];
    }
 
 
    virtual ~Data()
    {
-      //DELETE USED HERE
-      delete( (this)->read_pt );
-      delete( (this)->write_pt );
-      
       //FREE USED HERE
       if( ! (this)->external_alloc )
       {
-#if (defined _WIN64 ) || (defined _WIN32) 
+#if (defined _WIN64 ) || (defined _WIN32)
 		 _aligned_free( (this)->store );
 #else
          free( (this)->store );
@@ -195,22 +206,25 @@ template < class T >
          const std::size_t max_cap,
          const std::size_t start_position ) : ourtype_t( max_cap )
    {
-      assert( ptr != nullptr );
-      (this)->store  = reinterpret_cast< type_t* >( ptr );
-      (this)->signal = (Signal*)       calloc( 1,
-                                               sizeof( Signal ) );
-      if( (this)->signal == nullptr )
-      {
-         perror( "Failed to allocate signal queue!" );
-         exit( EXIT_FAILURE );
-      }
-      /** set index to be start_position **/
-      (this)->signal[ 0 ].index  = start_position; 
-      /** allocate read and write pointers **/
-      (this)->read_pt   = new Pointer( max_cap );
-      (this)->write_pt  = new Pointer( max_cap, 1 ); 
-      
-      (this)->external_alloc = true;
+        assert( ptr != nullptr );
+        (this)->store  = reinterpret_cast< type_t* >( ptr );
+        (this)->signal = (Signal*)       calloc( 1,
+                                                 sizeof( Signal ) );
+        if( (this)->signal == nullptr )
+        {
+           perror( "Failed to allocate signal queue!" );
+           exit( EXIT_FAILURE );
+        }
+        /** set index to be start_position **/
+        (this)->signal[ 0 ].index  = start_position; 
+        /** allocate read and write pointers **/
+        
+        /** allocate read and write pointers **/
+        new ( &(this)->read_pt ) Pointer( max_cap );
+        new ( &(this)->write_pt ) Pointer( max_cap, 1 ); 
+        new ( &(this)->read_stats ) Blocked();
+        new ( &(this)->write_stats ) Blocked();
+        (this)->external_alloc = true;
    }
 
 
@@ -230,7 +244,7 @@ template < class T >
       }
 #elif (defined _WIN64 ) || (defined _WIN32) 
 //FIXME, we need to test this on Win sys before making live    
-      (this)->store = reinterpret_cast< type_t* >(  _aligned_malloc((this)->length_store, align));
+      (this)->store = reinterpret_cast< type_t* >(  _aligned_malloc( (this)->length_store ) );
 #else
       /** 
        * would use the array allocate, but well...we'd have to 
@@ -238,6 +252,7 @@ template < class T >
        */
       (this)->store = reinterpret_cast< type_t* >( malloc( (this)->length_store ) );
 #endif
+      //FIXME - this should be an exception 
       assert( (this)->store != nullptr );
       
 #if (defined __linux ) || (defined __APPLE__ )
@@ -245,60 +260,61 @@ template < class T >
                      (this)->length_store,  
                      POSIX_MADV_SEQUENTIAL );
 #endif
-      errno = 0;
-      (this)->signal = (Signal*)       calloc( (this)->max_cap,
-                                               sizeof( Signal ) );
-      if( (this)->signal == nullptr )
-      {
-         perror( "Failed to allocate signal queue!" );
-         exit( EXIT_FAILURE );
-      }
-      /** allocate read and write pointers **/
-      /** TODO, see if there are optimizations to be made with sizing and alignment **/
-      (this)->read_pt   = new Pointer( max_cap );
-      (this)->write_pt  = new Pointer( max_cap ); 
+        errno = 0;
+        (this)->signal = (Signal*)       calloc( (this)->max_cap,
+                                                 sizeof( Signal ) );
+        if( (this)->signal == nullptr )
+        {
+           perror( "Failed to allocate signal queue!" );
+           exit( EXIT_FAILURE );
+        }
+        /** allocate read and write pointers **/
+        new ( &(this)->read_pt ) Pointer( max_cap );
+        new ( &(this)->write_pt) Pointer( max_cap ); 
+        new ( &(this)->read_stats ) Blocked();
+        new ( &(this)->write_stats ) Blocked();
    }
    
    virtual void copyFrom( ourtype_t *other )
    {
-      //TODO, figure something better out for here 
-      if( other->external_alloc )
-      {
-         assert( false );
-      }
-      delete( (this)->read_pt );
-      (this)->read_pt = new Pointer( (other->read_pt),   (this)->max_cap );
-      delete( (this)->write_pt );
-      (this)->write_pt = new Pointer( (other->write_pt), (this)->max_cap );
+        if( other->external_alloc )
+        {
+            //FIXME: throw rafterror that is synchronized
+            std::cerr << 
+                "FATAL: Attempting to resize a FIFO that is statically alloc'd\n";
+            exit( EXIT_FAILURE );
+        }
+        new ( &(this)->read_pt  ) Pointer( (other->read_pt),   
+                                           (this)->max_cap );
+        new ( &(this)->write_pt ) Pointer( (other->write_pt), 
+                                           (this)->max_cap );
+        (this)->is_valid = other->is_valid;
 
-      (this)->src_kernel = other->src_kernel;
-      (this)->dst_kernel = other->dst_kernel;
-      
-      (this)->is_valid = other->is_valid;
-
-      /** buffer is already alloc'd, copy **/
-      std::memcpy( (void*)(this)->store /* dst */,
-                   (void*)other->store  /* src */,
-                   other->length_store );
-      /** copy signal buff **/
-      std::memcpy( (void*)(this)->signal /* dst */,
-                   (void*)other->signal  /* src */,
-                   other->length_signal );
-      /** everything should be put back together now **/
+        /** buffer is already alloc'd, copy **/
+        std::memcpy( (void*)(this)->store /* dst */,
+                     (void*)other->store  /* src */,
+                     other->length_store );
+        /** copy signal buff **/
+        std::memcpy( (void*)(this)->signal /* dst */,
+                     (void*)other->signal  /* src */,
+                     other->length_signal );
+        //copy over block stats objects
+        (this)->read_stats  = other->read_stats; 
+        (this)->write_stats = other->write_stats;
+        
+        (this)->thread_access[ 0 ] = other->thread_access[ 0 ]; 
+        (this)->thread_access[ 1 ] = other->thread_access[ 1 ];
+        /** everything should be put back together now **/
    }
 
 
    virtual ~Data()
    {
-      //DELETE USED HERE
-      delete( (this)->read_pt );
-      delete( (this)->write_pt );
-      
       //FREE USED HERE
       if( ! (this)->external_alloc )
       {
 #if (defined _WIN64 ) || (defined _WIN32) 
-		  _aligned_free( (this)->store );
+		 _aligned_free( (this)->store );
 #else
          free( (this)->store );
 #endif
@@ -308,7 +324,7 @@ template < class T >
 
 }; /** end heap > Line Size **/
 
-#if BUILDSHM
+
 template < class T > struct Data< T, Type::SharedMemory > : 
    public DataBase< T > 
 {
@@ -331,8 +347,10 @@ template < class T > struct Data< T, Type::SharedMemory > :
          const size_t alignment ) : DataBase< T >( max_cap ),
                                     store_key( shm_key + "_store" ),
                                     signal_key( shm_key + "_key" ),
-                                    ptr_key( shm_key + "_ptr" )
+                                    ptr_key( shm_key + "_ptr" ),
+                                    dir( dir )
    {
+      UNUSED( alignment );
       /** now work through opening SHM **/
       switch( dir )
       {
@@ -343,7 +361,7 @@ template < class T > struct Data< T, Type::SharedMemory > :
             {
                try
                {
-                  *ptr = SHM::Init( key, length );
+                  *ptr = shm::init( key, length );
                }catch( bad_shm_alloc &ex )
                {
                   std::cerr << 
@@ -360,19 +378,14 @@ template < class T > struct Data< T, Type::SharedMemory > :
             alloc_with_error( (void**)&(this)->signal, 
                               (this)->length_signal, 
                               signal_key.c_str() );
-            alloc_with_error( (void**)&(this)->read_pt, 
-                              (sizeof( Pointer ) * 2 ) + sizeof( Cookie ), 
-                              ptr_key.c_str() );
 
-            (this)->write_pt = &(this)->read_pt[ 1 ];
+            new ( &(this)->write_pt ) Pointer( max_cap ); 
+            new ( &(this)->write_stats ) Blocked();
             
-            Pointer temp( max_cap );
-            std::memcpy( (this)->read_pt,  &temp, sizeof( Pointer ) );
-            std::memcpy( (this)->write_pt, &temp, sizeof( Pointer ) );
+
+            (this)->cookie.producer = 0x1337;
             
-            (this)->cookie   = (Cookie*) &(this)->read_pt[ 2 ];
-            (this)->cookie->producer = 0x1337;
-            while( (this)->cookie->consumer != 0x1337 )
+            while( (this)->cookie.consumer != 0x1337 )
             {
                std::this_thread::yield();
             }
@@ -388,7 +401,7 @@ template < class T > struct Data< T, Type::SharedMemory > :
                {
                   try
                   {
-                     *ptr = SHM::Open( str );
+                     *ptr = shm::open( str );
                   }
                   catch( bad_shm_alloc &ex )
                   {
@@ -409,23 +422,16 @@ template < class T > struct Data< T, Type::SharedMemory > :
             };
             retry_func( (void**) &(this)->store,  store_key.c_str() );
             retry_func( (void**) &(this)->signal, signal_key.c_str() );
-            retry_func( (void**) &(this)->read_pt, ptr_key.c_str() );
             
             assert( (this)->store != nullptr );
             assert( (this)->signal != nullptr );
-            assert( (this)->read_pt   != nullptr );
             
-            /** fix write_pt **/
-            (this)->write_pt  = &(this)->read_pt[ 1 ];
-            assert( (this)->write_pt  != nullptr );
-            (this)->cookie    = (Cookie*)&(this)->read_pt[ 2 ]; 
+            new ( &(this)->read_pt ) Pointer( max_cap );
+            new ( &(this)->read_stats ) Blocked();
             
-            Pointer temp( max_cap );
-            std::memcpy( (this)->read_pt,  &temp, sizeof( Pointer ) );
-            std::memcpy( (this)->write_pt, &temp, sizeof( Pointer ) );
-            
-            (this)->cookie->consumer = 0x1337;
-            while( (this)->cookie->producer != 0x1337 )
+
+            (this)->cookie.consumer = 0x1337;
+            while( (this)->cookie.producer != 0x1337 )
             {
                std::this_thread::yield();
             }
@@ -441,44 +447,66 @@ template < class T > struct Data< T, Type::SharedMemory > :
       /** should be all set now **/
    }
 
-   virtual void copyFrom( DataBase< T > *other )
+   virtual ~Data()
    {
-      assert( false );
-      /** TODO, implement me **/
-   }
+      switch( dir )
+      {
+         case( Direction::Producer ):
+         {
+            delete( &(this)->write_pt ); 
+            delete( &(this)->write_stats );
+         }
+         break;
+         case( Direction::Consumer ):
+         { 
+            delete( &(this)->read_pt );
+            delete( &(this)->read_stats );
+         }
+         break;
+         default:
+            assert( false );
+      } /** end switch **/
+      
+       //FREE USED HERE
+       if( ! (this)->external_alloc )
+       {
+          /** three segments of SHM to close **/
+          shm::close( store_key.c_str(), 
+                      (void**) &(this)->store, 
+                      (this)->length_store,
+                      false,
+                      true );
 
-   ~Data()
-   {
-      /** three segments of SHM to close **/
-      SHM::Close( store_key.c_str(), 
-                  (void*) (this)->store, 
-                  (this)->length_store,
-                  false,
-                  true );
-      SHM::Close( signal_key.c_str(),
-                  (void*) (this)->signal,
-                  (this)->length_signal,
-                  false,
-                  true );
-      SHM::Close( ptr_key.c_str(),   
-                  (void*) (this)->read_pt, 
-                  (sizeof( Pointer ) * 2) + sizeof( Cookie ),
-                  false,
-                  true );
-   }
-   struct Cookie
-   {
-      std::int32_t producer;
-      std::int32_t consumer;;
-   };
+       }
+       shm::close( signal_key.c_str(),
+                   (void**) &(this)->signal,
+                   (this)->length_signal,
+                   false,
+                   true );
+       }
 
-   volatile Cookie         *cookie;
+       virtual void copyFrom( DataBase< T > *other )
+       {
+          UNUSED( other );
+          assert( false );
+          /** TODO, implement me **/
+       }
+
+       struct Cookie
+       {
+          std::int32_t producer;
+          std::int32_t consumer;
+       };
+
+   volatile Cookie         cookie;
 
    /** process local key copies **/
    const std::string store_key; 
    const std::string signal_key;  
    const std::string ptr_key; 
+   const Direction   dir;
 };
-#endif //END BUILDSHM
+
+
 } //end namespace Buffer
-#endif /* END BUFFERDATA_TCC */
+#endif /* END RAFTBUFFERDATA_TCC */

--- a/raftinc/bufferdata.tcc
+++ b/raftinc/bufferdata.tcc
@@ -100,8 +100,7 @@ template < class T > struct Data< T,
          exit( EXIT_FAILURE );
       }
 #elif (defined _WIN64 ) || (defined _WIN32) 
-//FIXME, we need to test this on Win sys before making live    
-      (this)->store = reinterpret_cast< T* >(  _aligned_malloc( (this)->length_store ) );
+      (this)->store = reinterpret_cast< T* >(  _aligned_malloc( (this)->length_store, align ) );
 #else
       /** 
        * would use the array allocate, but well...we'd have to 
@@ -244,8 +243,7 @@ template < class T >
          exit( EXIT_FAILURE );
       }
 #elif (defined _WIN64 ) || (defined _WIN32) 
-//FIXME, we need to test this on Win sys before making live    
-      (this)->store = reinterpret_cast< type_t* >(  _aligned_malloc( (this)->length_store ) );
+      (this)->store = reinterpret_cast< type_t* >(  _aligned_malloc( (this)->length_store, align ) );
 #else
       /** 
        * would use the array allocate, but well...we'd have to 

--- a/raftinc/database.tcc
+++ b/raftinc/database.tcc
@@ -23,7 +23,8 @@
 #include "pointer.hpp"
 #include "signal.hpp"
 #include <cstddef>
-
+#include "blocked.hpp"
+#include "threadaccess.hpp"
 
 namespace raft
 {
@@ -40,86 +41,68 @@ namespace Buffer
  */
 template < class T > struct DataBase 
 {
-   DataBase( const std::size_t max_cap ) : max_cap ( max_cap ),
-                                           length_store( sizeof( T ) * max_cap ),
-                                           length_signal( sizeof( T ) * max_cap ){}
+    DataBase( const std::size_t max_cap ) : max_cap ( max_cap ),
+                                            length_store( sizeof( T ) * max_cap ),
+                                            length_signal( sizeof( T ) * max_cap ),
+                                            dynamic_alloc_size( length_store +
+                                                                length_signal )
+                                            {}
 
-   /** 
-    * copyFrom - implement in all sub-structs to 
-    * copy the buffer.  Might need to reinterpret
-    * cast the other object or other type of cast
-    * in order to get all the data members you wish
-    * to copy.
-    * @param   other - struct to be copied
-    */
-   virtual void copyFrom( DataBase< T > *other ) = 0;
-
-
-   /**
-    * setSourceKernel - set the source kernel 
-    * so that an object using this buffer can
-    * have access to it, these must be preserved
-    * across copies.  Null kernel references 
-    * will fail an assertion and exit the program.
-    * @param    k - raft::kernel * const
-    */
-   inline void setSourceKernel( raft::kernel * const k )
-   {
-      assert( k != nullptr );
-      src_kernel = k;
-      return;
-   }
-
-   /**
-    * setDestKernel - set the destination kernel 
-    * so that an object using this buffer can
-    * have access to it, these must be preserved
-    * across copies.  Null kernel references 
-    * will fail an assertion and exit the program.
-    * @param    k - raft::kernel * const
-    */
-   inline void setDestKernel( raft::kernel * const k ) 
-   {
-      assert( k != nullptr );
-      dst_kernel = k;
-      return;
-   }
-
-   const std::size_t        max_cap;
-   /** sizes, might need to define a local type **/
-   const std::size_t       length_store;
-   const std::size_t       length_signal;
-   
-   /** 
-    * allocating these as structs gives a bit
-    * more flexibility later in what to pass
-    * along with the queue.  It'll be more 
-    * efficient copy wise to pass extra items
-    * in the signal, but conceivably there could
-    * be a case for adding items in the store
-    * as well.
-    */
-   Pointer                 *read_pt   = nullptr;
-   Pointer                 *write_pt  = nullptr;
-   
-   
-   T                       *store         = nullptr;
-   Signal                  *signal        = nullptr;
-   bool                    external_alloc = false;
-   /** variable set by scheduler, used for shutdown **/
-   bool                    is_valid       = true;
+    /** 
+     * copyFrom - implement in all sub-structs to 
+     * copy the buffer.  Might need to reinterpret
+     * cast the other object or other type of cast
+     * in order to get all the data members you wish
+     * to copy.
+     * @param   other - struct to be copied
+     */
+    virtual void copyFrom( DataBase< T > *other ) = 0;
 
 
-   /**
-    * need a reference to source and destination 
-    * kernels for preemption to work properly, essentially
-    * there has to be a way to give orderly control from
-    * the fifo copying data back to the scheduler and the
-    * only realistic way is through the kernel.  These
-    * must be preserved across copies.
-    */
-   raft::kernel            *src_kernel      = nullptr;
-   raft::kernel            *dst_kernel      = nullptr;
+    const std::size_t       max_cap;
+    /** sizes, might need to define a local type **/
+    const std::size_t       length_store;
+    const std::size_t       length_signal;
+    
+    const std::size_t       dynamic_alloc_size;
+
+
+    /**
+     * read/write pointer. the thread_access is in 
+     * between as it's well accessed by both just
+     * as frequently as the pointers themselves, 
+     * so we get decent caching behavior out of 
+     * doing it this way. 
+     */
+    Pointer                 read_pt;
+    ThreadAccess            thread_access[ 2 ];
+    Pointer                 write_pt;
+    
+    /** 
+     * FIXME - decide if 32 is the best choice or have
+     * a macro that defines it per compile.
+     */
+    T                       *store          = nullptr;
+    Signal                  *signal         = nullptr;
+    bool                    external_alloc  = false;
+    /** variable set by scheduler, used for shutdown **/
+    bool                    is_valid        = true;
+    
+    /**
+     * these keep reference over how many read/writes are
+     * blocked. used for dynamic adaptation.
+     */
+    Blocked                 read_stats; 
+    Blocked                 write_stats;
+    
+    /** need to force resize, this has the count requested **/
+    std::size_t             force_resize    = 0;
+
+     
+    using value_type = T;
+
+    
+    const std::size_t       static_alloc_size = sizeof( DataBase< T > );
 };
 
 } /** end namespace Buffer **/

--- a/raftinc/datamanager.tcc
+++ b/raftinc/datamanager.tcc
@@ -28,25 +28,8 @@
 
 #include "ringbuffertypes.hpp"
 #include "bufferdata.tcc"
+#include "defs.hpp"
 
-namespace dm
-{
-using key_t = std::uint8_t;
-/**
- * access_key - each one of these is to be used as a 
- * key for  buffer access functions.  Everything <= 
- * push is expected to be a write type function, everything
- * else is expected to be a read type operation.
- */
-enum access_key : key_t { allocate       = 0, 
-                          allocate_range = 1, 
-                          push           = 3, 
-                          recycle        = 4, 
-                          pop            = 5, 
-                          peek           = 6, 
-                          size           = 7,
-                          NKEY };
-}
 
 template < class T, 
            Type::RingBufferType B,
@@ -68,6 +51,12 @@ public:
       (this)->buffer = buffer;
       /** check to see if buffer is given is resizeable **/
       resizeable     = (  buffer->external_alloc ? false : true ); 
+      /** 
+       * need to set thread access structs, should be two of them, 
+       * one for producer anad other for the consumer. These are 
+       * kept as an array here so, only one ptr.
+       */
+      thread_access = buffer->thread_access;
    }
 
    inline bool is_resizeable() noexcept 
@@ -95,28 +84,31 @@ public:
        * if all fifo functions have completed
        * their operations.
        */
-      auto allclear = [&]() noexcept -> bool
+      auto allclear( []( ThreadAccess * const thread_access,
+                         std::atomic< std::uint64_t >  * checking_size ) noexcept -> bool
       {
-         for( const auto &flag_array : thread_access )
+         assert( thread_access != nullptr );
+         assert( checking_size != nullptr );
+         for( int i( 0 ); i < 2; i++ )
          {
-            if( flag_array.whole != 0 )
+            if( thread_access[ i ].whole != 0 )
             {
                return( false );
             }
          }
-         if( checking_size.load( std::memory_order_relaxed ) != 0 )
+         if( checking_size->load( std::memory_order_relaxed ) != 0 )
          {
             return( false );
          }
          return( true );
-      };
+      } );
 
       /**
        * buffercondition - call to see if the 
        * current buffer state is amenable to
        * expanding.
        */
-      auto buffercondition = [&]() noexcept -> bool
+      auto buffercondition( []( Buffer::Data< T, B > * const buff_ptr ) noexcept -> bool
       {
          /** 
           * there's only a few conditions that you can copy
@@ -129,11 +121,10 @@ public:
           * in the size() function from the ringbufferheap.tcc 
           * file.
           */
-         auto * const buff_ptr( get() );
          const auto rpt( Pointer::val( buff_ptr->read_pt  ) );
          const auto wpt( Pointer::val( buff_ptr->write_pt ) );
          return( rpt < wpt );
-      };
+      } );
       
       auto *old_buffer( get() );
       for(;;)
@@ -151,10 +142,10 @@ public:
          /** set resizing global flag **/
          resizing = true;
          /** see if everybody is done with the current buffer **/
-         if( allclear() )
+         if( allclear( thread_access, &checking_size ) )
          {
             /** check to see if the state of the buffer is good **/
-            if( buffercondition() )
+            if( buffercondition( old_buffer ) )
             {
                break;
             }
@@ -166,7 +157,15 @@ public:
          resizing = false;
          std::this_thread::yield();
       }
-      /** nobody should have outstanding references to the old buff **/
+      /** 
+       * we can't do this with a simple copy constructor easily as 
+       * at the time of new buffer creation we don't know the state
+       * of the buffer at the time the conditions above were met, so
+       * we have to do it once the happen. 
+       * 
+       * At this point nobody should have outstanding references to 
+       * the old buff, free to copy.
+       */
       new_buffer->copyFrom( old_buffer );
       set( new_buffer );
       delete( old_buffer );
@@ -179,6 +178,7 @@ public:
     */
    auto get() noexcept -> Buffer::Data< T, B >*
    {
+      /** don't check for nullptr here b/c it's a valid return type **/
       return( buffer );
    }
 
@@ -191,7 +191,10 @@ public:
    void enterBuffer( const dm::access_key key ) noexcept
    {
       /** see lambda below **/
-      set_helper( key, static_cast< dm::key_t >( 1 ) );
+      set_helper( key, 
+                  static_cast< dm::key_t >( 1 ),
+                  thread_access,
+                  &checking_size );
    }
 
    /**
@@ -203,7 +206,10 @@ public:
    void exitBuffer( const dm::access_key key ) noexcept
    {
       /** see lambda below **/
-      set_helper( key, static_cast< dm::key_t >( 0 ) );
+      set_helper( key, 
+                  static_cast< dm::key_t >( 0 ),
+                  thread_access,
+                  &checking_size );
    }
 
    /**
@@ -213,7 +219,7 @@ public:
     */
    bool notResizing() noexcept
    {
-      return( ! resizing ); 
+      return( R_UNLIKELY( ! resizing ) ); 
    }
    
 
@@ -223,25 +229,20 @@ private:
 
    bool                  resizeable          = true;
    
-   struct ThreadAccess
-   {
-      union
-      {
-         std::uint64_t whole = 0; /** just in case, default zero **/
-         dm::key_t     flag[ 8 ];
-      };
-      std::uint8_t padding[ L1D_CACHE_LINE_SIZE - 8 /** 64 padding **/ ];
-   } 
-#if defined __APPLE__ || defined __linux   
-    __attribute__((aligned( L1D_CACHE_LINE_SIZE ))) 
-#endif    
-    volatile thread_access[ 2 ];
+   /** defined in threadaccess.hpp **/
+   ThreadAccess *thread_access = nullptr;
   
    std::atomic< std::uint64_t >  checking_size = { 0 };
 
-   inline void set_helper( const dm::access_key key, 
-                           const dm::key_t      val ) noexcept
+   static inline void set_helper( const dm::access_key key, 
+                                  const dm::key_t      val,
+                                  ThreadAccess *thread_access,
+                                  std::atomic< 
+                                    std::uint64_t > * const checking_size ) noexcept
    {
+      assert( thread_access != nullptr );
+      assert( checking_size != nullptr );
+
       switch( key )
       {
          case( dm::allocate ):
@@ -279,11 +280,11 @@ private:
             /** this one has to be atomic, multiple updaters **/
             if( val == 0 )
             {
-                checking_size.fetch_sub( 1, std::memory_order_relaxed );
+                checking_size->fetch_sub( 1, std::memory_order_relaxed );
             }
             else
             {
-                checking_size.fetch_add( 1, std::memory_order_relaxed );
+                checking_size->fetch_add( 1, std::memory_order_relaxed );
             }
          }
          break;

--- a/raftinc/defs.hpp
+++ b/raftinc/defs.hpp
@@ -1,9 +1,9 @@
 /**
  * defs.hpp - 
  * @author: Jonathan Beard
- * @version: Mon Sep  3 16:20:48 2018
+ * @version: Sun Feb  7 05:46:48 2016
  * 
- * Copyright 2018 Jonathan Beard
+ * Copyright 2016 Jonathan Beard
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,12 +26,19 @@
 #include <cstdint>
 #include <vector>
 #include <utility>
+#include <climits>
+#include <bitset>
+#include <memory>
+#include <string>
 
-
-/** predeclare raft::kernel for kernel_list_t below **/
 namespace raft
 {
+    /** predeclare raft::kernel for kernel_list_t below **/
     class kernel;
+    /** also parsemap_ptr smart ptr obj used in map and streamparse **/
+    class parsemap;
+    using port_key_type = std::string;
+    using parsemap_ptr = std::shared_ptr< raft::parsemap >;
 } /** end namespace raft **/
 
 template < typename T > 
@@ -49,6 +56,7 @@ using weight_t  = std::int32_t;
 /** type for edge id, largely used by graph.tcc and partition_scotch.hpp **/
 using edge_id_t = std::int32_t;
 
+
 #ifndef UNUSED 
 #ifdef __clang__
 #define UNUSED( x ) (void)(x)
@@ -58,6 +66,7 @@ using edge_id_t = std::int32_t;
 //FIXME need to double check to see IF THIS WORKS ON MSVC
 #endif
 
+
 /** type for return from += you'll get an iterator to one of these **/
 using kernel_list_t  = std::vector< std::reference_wrapper< raft::kernel > >;
 using kernel_it_pair = std::pair< 
@@ -65,24 +74,79 @@ using kernel_it_pair = std::pair<
                                     typename kernel_list_t::const_iterator
                                 >;
 
-using byte_t = std::uint8_t;
-
-
-#if (defined __linux) || (defined __APPLE__ )
-
-#define R_LIKELY( var ) __builtin_expect( var, 1 )
-#define R_UNLIKELY( var ) __builtin_expect( var, 0 )
-
-#else
-
-#define R_LIKELY( var ) var
-#define R_UNLIKELY( var ) var
-
-#endif
-
 namespace raft
 {
+    using byte_t = std::uint8_t;
+    const static std::uint8_t bits_per_byte = CHAR_BIT;
+}
+
+/** system config defs **/
+namespace raft
+{
+
+/** 
+ * type for stream manipulation, currently
+ * this means that there are 64 available
+ * modifiers. we can always make this a 
+ * longer array at a later point if we 
+ * for some reason need more.
+ */
+using manip_vec_t = std::uint64_t;
+
+/**
+ * NOTE: in addition to registering the int type here
+ * for parsing, if a developer wants to add another
+ * state, there must a corresponding static function
+ * defined in the mapbase file so that the 
+ * parse function pointers can be called for the 
+ * appropriate int below and perform the correct
+ * setting actions for each kernel
+ */
+
+/** raft::parallel **/
+namespace parallel
+{
+
+enum type : manip_vec_t { 
+    system = 0  /** do whatever the runtime wants, I don't care  **/,
+    thread      /** specify a thread for each kernel **/, 
+    pool        /** thread pool, one kernel thread per core, many kernels in each **/, 
+    process     /** open a new process from this point **/,
+    PARALLEL_N };    
+} /** end namespace parallel **/ 
+
+/** raft::vm **/
+namespace vm
+{
+
+enum type : manip_vec_t { 
+    flat = parallel::PARALLEL_N       /** not yet implemented, likely using segment  **/, 
+    standard                          /** threads share VM space, processes have sep **/, 
+    partition                         /** partition graph at this point into a 
+                                        * new VM space, platform dependent **/,
+    VM_N
+}; 
+} /** end namespace vm **/
+
+namespace order
+{
+enum spec : std::uint8_t { 
+    in = vm::VM_N, 
+    out, 
+    ORDER_N 
+};
+} /** end namespace order **/
+
+
+/**
+ * these are to enable the sub-kernel behavior where 
+ * the kernel specifies that all ports must be active 
+ * before firing the kernel...by "active" we mean that
+ * all ports have some data.
+ */
 enum schedule_behavior : std::uint8_t { any_port = 0,
                                         all_port = 1 };
-}
+
+} /** end namespace raft **/
+
 #endif /* END RAFTDEFS_HPP */

--- a/raftinc/fifo.hpp
+++ b/raftinc/fifo.hpp
@@ -182,13 +182,7 @@ public:
       void *ptr( nullptr );
       /** call blocks till an element is available **/
       local_allocate( &ptr );
-#ifdef _MSC_VER // MSVC does not support __attribute__
-      T * temp(
-#else
-      T* __attribute__((__unused__)) temp(
-#endif
-         new (ptr) T( std::forward< Args >( params )... ) );
-      UNUSED( temp );
+      new (ptr) T( std::forward< Args >( params )... );
       return( autorelease< T, allocatetype >( 
          reinterpret_cast< T* >( ptr ), (*this) ) );
    }
@@ -510,6 +504,17 @@ public:
     * @return float
     */
    virtual float get_frac_write_blocked() = 0;
+    
+    /**
+     * get_suggested_count - returns the suggested count
+     * for the dynamic allocator if the user has ever
+     * asked for more than is currently available 
+     * space in the FIFO. This could also serve as a 
+     * minimum size for future allocations (implementation
+     * dependent.
+     * @return  std::size_t suggested count
+     */
+     virtual std::size_t get_suggested_count() = 0;
 
    /**
     * invalidate - used by producer thread to label this
@@ -546,20 +551,6 @@ protected:
     * setOutPeekSet -
     */
    virtual void setOutPeekSet( ptr_set_t * const peekset );
-   /**
-    * set_src_kernel - sets teh protected source
-    * kernel for this fifo, necessary for preemption,
-    * see comments on variables below.
-    * @param   k - raft::kernel*
-    */
-   virtual void set_src_kernel( raft::kernel * const k ) = 0;
-   /**
-    * set_dst_kernel - sets the protected destination
-    * kernel for this fifo, necessary for preemption,
-    * see comments on variables below.
-    * @param   k - raft::kernel*
-    */
-   virtual void set_dst_kernel( raft::kernel * const k ) = 0;
    /**
     * signal_peek - special function for the scheduler
     * to peek at a signal on the head of the queue.

--- a/raftinc/fifoabstract.tcc
+++ b/raftinc/fifoabstract.tcc
@@ -25,19 +25,62 @@
 #include "bufferdata.tcc"
 #include "blocked.hpp"
 #include "fifo.hpp"
-
+#include "datamanager.tcc"
+#include "defs.hpp"
+#include "internaldefs.hpp"
 
 template < class T, Type::RingBufferType type > 
    class FIFOAbstract : public FIFO
 {
 public:
-   FIFOAbstract() : FIFO()
-   {
-   }
+   FIFOAbstract() : FIFO(){}
 
 protected:
-   /** TODO, package this as as struct **/
-   volatile bool            allocate_called = false;
-   Blocked::value_type      n_allocated     = 1;
+
+    inline void init() noexcept
+    {
+        auto * const buffer( datamanager.get() );
+        assert( buffer != nullptr );
+        producer_data.write_stats = &buffer->write_stats;
+        consumer_data.read_stats  = &buffer->read_stats;
+    }
+
+    struct ALIGN( L1D_CACHE_LINE_SIZE ) {
+        volatile bool            allocate_called = false;
+        Blocked::value_type      n_allocated     = 1;
+        /**
+         * these pointers are set by the scheduler which 
+         * calls the garbage collection function. these
+         * two capture the addresses of output pointers
+         */
+        ptr_set_t                   *out         = nullptr;
+        ptr_set_t                   *out_peek    = nullptr;
+        /** 
+         * this is set via init callback on fifo construction
+         * this prevents the re-calculating of the address
+         * over and over....pointer chasing is very bad
+         * for cache performance.
+         */
+        Blocked                     *write_stats = nullptr;
+    } producer_data;
+   
+   
+    struct  ALIGN( L1D_CACHE_LINE_SIZE ) {
+        /**
+         * these pointers are set by the scheduler which 
+         * calls the garbage collection function. these
+         * two capture the addresses of output pointers
+         */
+        ptr_map_t                   *in         = nullptr;
+        ptr_set_t                   *in_peek    = nullptr;
+        Blocked                     *read_stats = nullptr;
+    } consumer_data;
+    
+    /** 
+     * upgraded the *data structure to be a DataManager
+     * object to enable easier and more intuitive dynamic
+     * lock free buffer resizing and re-alignment.
+     */
+    DataManager< T, type >       datamanager;
 };
 #endif /* END RAFTFIFOABSTRACT_TCC */

--- a/raftinc/kpair.hpp
+++ b/raftinc/kpair.hpp
@@ -1,9 +1,9 @@
 /**
  * kpair.hpp - 
  * @author: Jonathan Beard
- * @version: Wed Dec  9 11:36:08 2015
+ * @version: 25 May 2020 
  * 
- * Copyright 2015 Jonathan Beard
+ * Copyright 2020 Jonathan Beard
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@
 
 #include <string>
 #include "kset.tcc"
-#include "portorder.hpp"
 #include "defs.hpp"
 
 namespace raft

--- a/raftinc/map.hpp
+++ b/raftinc/map.hpp
@@ -122,7 +122,7 @@ public:
       }
       catch( std::exception &ex )
       {
-        std::cerr << "caught here\n"; 
+        std::cerr << "Exception caught with (" << ex.what() << ")\n"; 
       }
       scheduler sched( (*this) );
       sched.init();

--- a/raftinc/mapbase.hpp
+++ b/raftinc/mapbase.hpp
@@ -10,9 +10,9 @@
  * within it.  
  *
  * @author: Jonathan Beard
- * @version: Sun July 23 06:22 2017
+ * @version: 25 May 2020 
  * 
- * Copyright 2017 Jonathan Beard
+ * Copyright 2020 Jonathan Beard
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@
 #include <vector>
 #include <thread>
 #include <sstream>
-
+#include "defs.hpp"
 #include "kernelkeeper.tcc"
 #include "portexception.hpp"
 #include "schedule.hpp"
@@ -44,7 +44,6 @@
 #include "dynalloc.hpp"
 #include "stdalloc.hpp"
 #include "kpair.hpp"
-#include "portorder.hpp"
 #include "kernel_pair_t.hpp"
 
 class MapBase

--- a/raftinc/poolschedule.hpp
+++ b/raftinc/poolschedule.hpp
@@ -36,6 +36,7 @@
 using aligned_t = std::uint64_t;
 #endif
 #include "schedule.hpp"
+#include "internaldefs.hpp"
 
 namespace raft{
    class kernel;
@@ -86,7 +87,7 @@ protected:
      * since we don't really need some of the info. this
      * is passed to each kernel within teh pool_run func
      */
-    struct alignas( 64 ) thread_data
+    struct ALIGN( 64 ) thread_data
     {
        constexpr thread_data( raft::kernel * const k ) : k( k ){}
 

--- a/raftinc/ringbuffer.tcc
+++ b/raftinc/ringbuffer.tcc
@@ -30,11 +30,13 @@
 #include <thread>
 #include <utility>
 #include <vector>
-#include <shm>
 
 #include "fifoabstract.tcc"
 #include "ringbufferbase.tcc"
 #include "ringbuffertypes.hpp"
+
+
+
 //#include "sample.tcc"
 //#include "meansampletype.tcc"
 //#include "arrivalratesampletype.tcc"

--- a/raftinc/ringbuffer.tcc
+++ b/raftinc/ringbuffer.tcc
@@ -30,7 +30,9 @@
 #include <thread>
 #include <utility>
 #include <vector>
+#include <shm>
 
+#include "fifoabstract.tcc"
 #include "ringbufferbase.tcc"
 #include "ringbuffertypes.hpp"
 //#include "sample.tcc"
@@ -57,7 +59,9 @@ public:
         : RingBufferBase<T, type>()
     {
         assert(n != 0);
-        (this)->datamanager.set(new Buffer::Data<T, type>(n, align));
+        (this)->datamanager.set( new Buffer::Data<T, type>(n, align) );
+        /** set call-backs to structures inside buffer **/
+        (this)->init();
     }
 
     /**
@@ -72,6 +76,8 @@ public:
         T* ptrcast = reinterpret_cast<T*>(ptr);
         (this)->datamanager.set(
             new Buffer::Data<T, type>(ptrcast, length, start_position));
+        /** set call-backs to structures inside buffer **/
+        (this)->init();
     }
 
     virtual ~RingBuffer()
@@ -122,16 +128,6 @@ public:
         return;
     }
 
-    virtual float get_frac_write_blocked()
-    {
-        const auto copy((this)->write_stats);
-        (this)->write_stats.all = 0;
-        if(copy.bec.blocked == 0 || copy.bec.count == 0)
-        {
-            return (0.0);
-        }
-        return ((float)copy.bec.blocked / (float)copy.bec.count);
-    }
 };
 
 
@@ -147,7 +143,7 @@ public:
         : RingBufferBase<T, type>(), term(false)
     {
         (this)->datamanager.set(new Buffer::Data<T, Type::Heap>(n, align));
-
+        (this)->init();
         /** add monitor types immediately after construction **/
         // sample_master.registerSample( new MeanSampleType< T, type >() );
         // sample_master.registerSample( new ArrivalRateSampleType< T, type >()
@@ -195,17 +191,6 @@ public:
         return;
     }
 
-    virtual float get_frac_write_blocked()
-    {
-        const auto copy((this)->write_stats);
-        (this)->write_stats.all = 0;
-        if(copy.bec.blocked == 0 || copy.bec.count == 0)
-        {
-            return (0.0);
-        }
-        return ((float)copy.bec.blocked / (float)copy.bec.count);
-    }
-
 protected:
     // std::thread       *monitor;
     volatile bool term;
@@ -235,7 +220,7 @@ public:
     {
         UNUSED( data );
         assert(data == nullptr);
-        return (new RingBuffer<T, Type::Heap, true>(n_items, align));
+        return( new RingBuffer<T, Type::Heap, true>(n_items, align) );
     }
 };
 
@@ -324,15 +309,10 @@ public:
         assert(false);
     }
 
-    virtual float get_frac_write_blocked()
-    {
-        /** TODO, implement me **/
-        assert(false);
-        return( static_cast< float >( 0.0 ) );
-    }
 };
 
-#if BUILDSHM
+
+
 /**
  * SharedMemory
  */
@@ -343,12 +323,16 @@ class RingBuffer< T, Type::SharedMemory, false >
 public:
     RingBuffer( const std::size_t nitems, 
                 const std::string key, 
-                Direction dir,
+                const Direction   dir,
                 const std::size_t alignment = 16 ) 
                     : RingBufferBase< T, 
                                       Type::SharedMemory >() ,
                       shm_key( key )
     {
+        //TODO this needs to be an shm::open
+        //TODO once open, needs to be an in-place allocate for
+        //the first object to get the open, otherwise..use cookie
+        //technique...all sub-keys will follow main key
         (this)->datamanager.set( 
             new Buffer::Data< T, Type::SharedMemory >( nitems, 
                                                        key, 
@@ -405,17 +389,13 @@ public:
         return;
     }
 
-    virtual float get_frac_write_blocked()
-    {
-        assert(false);
-        return( static_cast< float >( 0.0 ) );
-    }
 
 protected:
     const std::string shm_key;
 };
 
 
+#if 0
 /**
  * TCP w/ multiplexing
  */
@@ -424,10 +404,10 @@ class RingBuffer<T, Type::TCP, false /* no monitoring yet */>
     : public RingBufferBase<T, Type::Heap>
 {
 public:
-    RingBuffer( const std::size_t nitems, 
-                const std::string dns_name,
-                Direction dir, 
-                const std::size_t alignment = 16 ) 
+    RingBuffer( const std::size_t   nitems, 
+                const std::string   dns_name,
+                const Direction     dir, 
+                const std::size_t   alignment = 16 ) 
                     : RingBufferBase<T, Type::Heap>()
     {
         // TODO, fill in stuff here, perhaps from original....
@@ -469,13 +449,9 @@ public:
         return;
     }
 
-    virtual float get_frac_write_blocked()
-    {
-        assert(false);
-        return( static_cast< float >( 0.0 ) );
-    }
 
 protected:
 };
-#endif // end BUILDSHM
+#endif //TCP 
+
 #endif /* END RAFTRINGBUFFER_TCC */

--- a/raftinc/ringbufferbase.tcc
+++ b/raftinc/ringbufferbase.tcc
@@ -56,14 +56,15 @@ template < class T,
 class RingBufferBase
 {
 public:
-    RingBufferBase() = delete;
-    virtual ~RingBufferBase() = delete;
+    RingBufferBase() = default;
+    virtual ~RingBufferBase() = default;
+protected:   
 };
 
-
-/** heap implementation, uses thread shared memory or SHM **/
+/** implementation that uses malloc/jemalloc/tcmalloc **/
 #include "ringbufferheap.tcc"
-
+/** heap implementation, uses thread shared memory or SHM **/
+#include "ringbuffershm.tcc"
 /** infinite dummy implementation, can use shared memory or SHM **/
 #include "ringbufferinfinite.tcc"
 

--- a/raftinc/ringbufferheap_abstract.tcc
+++ b/raftinc/ringbufferheap_abstract.tcc
@@ -22,9 +22,7 @@
 
 #include "portexception.hpp"
 #include "defs.hpp"
-#ifdef USEQTHREADS
-#include <qthread/qthread.hpp>
-#endif
+#include "sysschedutil.hpp"
 
 template < class T,  Type::RingBufferType type > 
 class RingBufferBaseHeap : public FIFOAbstract< T, type> 
@@ -48,10 +46,10 @@ public:
    {  
       for( ;; )
       {
-         datamanager.enterBuffer( dm::size );
-         if( datamanager.notResizing() )
+         (this)->datamanager.enterBuffer( dm::size );
+         if( (this)->datamanager.notResizing() )
          {
-            auto * const buff_ptr( datamanager.get() );
+            auto * const buff_ptr( (this)->datamanager.get() );
 TOP:      
             const auto   wrap_write( Pointer::wrapIndicator( buff_ptr->write_pt  ) ),
                          wrap_read(  Pointer::wrapIndicator( buff_ptr->read_pt   ) );
@@ -63,7 +61,7 @@ TOP:
                /** expect most of the time to be full **/
                if( R_LIKELY( wrap_read < wrap_write ) )
                {
-                  datamanager.exitBuffer( dm::size );
+                  (this)->datamanager.exitBuffer( dm::size );
                   return( buff_ptr->max_cap );
                }
                else if( wrap_read > wrap_write )
@@ -76,36 +74,30 @@ TOP:
                    * this is in fact the best of all possible returns (see 
                    * Leibniz or Candide for further info).
                    */
-#ifndef USEQTHREADS                   
-                  std::this_thread::yield();
-#else
-                  qthread_yield();
-#endif
+                  raft::yield();
                   goto TOP;
                }
                else
                {
-                  datamanager.exitBuffer( dm::size );
+                  (this)->datamanager.exitBuffer( dm::size );
                   return( 0 );
                }
             }
             else if( rpt < wpt )
             {
-               datamanager.exitBuffer( dm::size );
+               (this)->datamanager.exitBuffer( dm::size );
                return( wpt - rpt );
             }
             else if( rpt > wpt )
             {
-               datamanager.exitBuffer( dm::size );
+               (this)->datamanager.exitBuffer( dm::size );
                return( buff_ptr->max_cap - rpt + wpt ); 
             }
-            datamanager.exitBuffer( dm::size );
+            (this)->datamanager.exitBuffer( dm::size );
             return( 0 );
          }
-         datamanager.exitBuffer( dm::size );
-#ifdef USEQTHREADS                   
-                  qthread_yield();
-#endif
+         (this)->datamanager.exitBuffer( dm::size );
+         raft::yield();
       } /** end for **/
       return( 0 ); /** keep some compilers happy **/
    }
@@ -121,7 +113,7 @@ TOP:
     */
    virtual void invalidate()
    {
-      auto * const ptr( datamanager.get() );
+      auto * const ptr( (this)->datamanager.get() );
       ptr->is_valid = false;
       return;
    }
@@ -135,7 +127,7 @@ TOP:
     */
    virtual bool is_invalid()
    {
-      auto * const ptr( datamanager.get() );
+      auto * const ptr( (this)->datamanager.get() );
       return( ! ptr->is_valid );
    }
 
@@ -148,7 +140,7 @@ TOP:
     */
    virtual std::size_t   space_avail()
    {
-      return( datamanager.get()->max_cap - size() );
+      return( (this)->datamanager.get()->max_cap - size() );
    }
   
    /**
@@ -158,7 +150,7 @@ TOP:
     */
    virtual std::size_t   capacity() 
    {
-      return( datamanager.get()->max_cap );
+      return( (this)->datamanager.get()->max_cap );
    }
 
    
@@ -171,8 +163,11 @@ TOP:
     */
    virtual void get_zero_read_stats( Blocked &copy )
    {
-      copy.all       = read_stats.all;
-      read_stats.all = 0;
+      
+      auto &buff_ptr_stats( (this)->datamanager.get()->read_stats.all );
+      
+      copy.all          = buff_ptr_stats;;
+      buff_ptr_stats    = 0;
    }
 
    /**
@@ -183,22 +178,35 @@ TOP:
     */
    virtual void get_zero_write_stats( Blocked &copy )
    {
-      copy.all       = write_stats.all;
-      write_stats.all = 0;
+      auto &buff_ptr_stats( (this)->datamanager.get()->write_stats.all );
+      copy.all       = buff_ptr_stats;
+      buff_ptr_stats = 0;
    }
-
-   /**
-    * get_write_finished - does exactly what it says, 
-    * sets the param variable to true when all writes
-    * have been finished.  This particular funciton 
-    * might change in the future but for the moment
-    * its vital for instrumentation.
-    * @param   write_finished - bool&
-    */
-   virtual void get_write_finished( bool &write_finished )
-   {
-      write_finished = (this)->write_finished;
-   }
+    
+    virtual float get_frac_write_blocked()
+    {
+        auto &wr_stats( (this)->datamanager.get()->write_stats );
+        const auto copy( wr_stats );
+        wr_stats.all = 0;
+        if( copy.bec.blocked == 0 || copy.bec.count == 0 )
+        {
+            return( 0.0 );
+        }
+        /** else **/
+        return( (float) copy.bec.blocked / 
+                    (float) copy.bec.count );
+    }
+    
+    /**
+     * suggested size if the user asks for more than 
+     * is available. if that condition never occurs
+     * then this will always return zero. if it does
+     * then this value can serve as a minimum size
+     */
+    virtual std::size_t get_suggested_count()
+    {
+        return( (this)->datamanager.get()->force_resize );
+    }
    
 
 protected:
@@ -208,7 +216,7 @@ protected:
    virtual void setPtrMap( ptr_map_t * const in )
    {
        assert( in != nullptr );
-       (this)->in = in;
+       (this)->consumer_data.in = in;
    }
 
 
@@ -218,54 +226,19 @@ protected:
    virtual void setPtrSet( ptr_set_t * const out )
    {
        assert( out != nullptr );
-       (this)->out = out;
+       (this)->producer_data.out = out;
    }
 
    virtual void setInPeekSet( ptr_set_t * const peekset )
    {
        assert( peekset != nullptr );
-       (this)->in_peek = peekset;
+       (this)->consumer_data.in_peek = peekset;
    }
    
    virtual void setOutPeekSet( ptr_set_t * const peekset )
    {
        assert( peekset != nullptr );
-       (this)->out_peek = peekset;
-   }
-
-   /**
-    * set_src_kernel - sets teh protected source
-    * kernel for this fifo, necessary for preemption,
-    * see comments on variables below.
-    * @param   k - raft::kernel*
-    */
-   virtual void set_src_kernel( raft::kernel * const k )
-   {
-      assert( k != nullptr );
-      while( ! datamanager.notResizing() )
-      { 
-         /* spin */ 
-      }
-      auto * const buffer( datamanager.get() );
-      buffer->setSourceKernel( k );
-   }
-
-
-   /**
-    * set_dst_kernel - sets the protected destination
-    * kernel for this fifo, necessary for preemption,
-    * see comments on variables below.
-    * @param   k - raft::kernel*
-    */
-   virtual void set_dst_kernel( raft::kernel * const k )
-   {
-      assert( k != nullptr );
-      while( ! datamanager.notResizing() )
-      {
-         /* spin */
-      }
-      auto * const buffer( datamanager.get() );
-      buffer->setDestKernel( k );
+       (this)->producer_data.out_peek = peekset;
    }
 
    /**
@@ -285,7 +258,7 @@ protected:
        * this value since the elements all remain in their 
        * location relative to the start of the queue.
        */
-      auto * const buff_ptr( datamanager.get() );
+      auto * const buff_ptr( (this)->datamanager.get() );
       const size_t read_index( Pointer::val( buff_ptr->read_pt ) );
       return( buff_ptr->signal[ read_index ] /* make copy */ ); 
    }
@@ -422,37 +395,6 @@ protected:
       }
       return;
    }
-   
-   
-   /** 
-    * upgraded the *data structure to be a DataManager
-    * object to enable easier and more intuitive dynamic
-    * lock free buffer resizing and re-alignment.
-    */
-   DataManager< T, type >       datamanager;
-   
-   
-   
-   /**
-    * these two should go inside the buffer, they'll
-    * be accessed via the monitoring system.
-    */
-   Blocked                     read_stats;
-   Blocked                     write_stats;
-   /** 
-    * This should be okay outside of the buffer, its local 
-    * to the writing thread.  Variable gets set "true" in
-    * the allocate function and false when the push with
-    * only the signal argument is called.
-    */
-   /** TODO, this needs to get moved into the buffer for SHM **/
-   volatile bool                write_finished = false;
-   ptr_map_t                   *in = nullptr;
-   ptr_set_t                   *out = nullptr;
-   /** these are named with reference to the kernel, in == kernel in **/
-   ptr_set_t                   *in_peek  = nullptr;
-   ptr_set_t                   *out_peek = nullptr;
-   
 };
 
 #endif /* END RAFTRINGBUFFERHEAP_ABSTRACT_TCC */

--- a/raftinc/ringbuffershm.tcc
+++ b/raftinc/ringbuffershm.tcc
@@ -1,10 +1,10 @@
 /**
- * ringbufferheap.tcc -
+ * ringbuffershm.tcc - 
  * @author: Jonathan Beard
- * @version: Sun Sep  7 07:39:56 2014
- *
- * Copyright 2014 Jonathan Beard
- *
+ * @version: Sun Sep 11 05:03:58 2016
+ * 
+ * Copyright 2016 Jonathan Beard
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -17,8 +17,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef RAFTRINGBUFFERHEAP_TCC
-#define RAFTRINGBUFFERHEAP_TCC  1
+#ifndef RAFTRINGBUFFERSHM_TCC
+#define RAFTRINGBUFFERSHM_TCC  1
 
 #include "portexception.hpp"
 #include "ringbufferheap_abstract.tcc"
@@ -26,19 +26,19 @@
 #include "alloc_traits.tcc"
 #include "prefetch.hpp"
 #include "defs.hpp"
-/** for yield **/
 #include "sysschedutil.hpp"
+
 
 /** inline alloc **/
 template < class T >
 class RingBufferBase<
     T,
-    Type::Heap,
+    Type::SharedMemory,
     typename std::enable_if< inline_nonclass_alloc< T >::value >::type >
-: public RingBufferBaseHeap< T, Type::Heap >
+: public RingBufferBaseHeap< T, Type::SharedMemory >
 {
 public:
-   RingBufferBase() : RingBufferBaseHeap< T, Type::Heap >()
+   RingBufferBase() : RingBufferBaseHeap< T, Type::SharedMemory >()
    {
    }
 
@@ -305,12 +305,6 @@ protected:
        }
       buff_ptr->signal[ write_index ]         = signal;
        Pointer::inc( buff_ptr->write_pt );
-#if 0       
-      if( signal == raft::quit )
-      {
-         (this)->write_finished = true;
-      }
-#endif      
       (this)->datamanager.exitBuffer( dm::push );
    }
 
@@ -348,8 +342,8 @@ protected:
             {
                rd_stats  = 1;
             }
+            raft::yield();
          }
-         raft::yield();
       }
       auto * const buff_ptr( (this)->datamanager.get() );
       const std::size_t read_index( Pointer::val( buff_ptr->read_pt ) );
@@ -451,7 +445,7 @@ protected:
            :
            : );
 #endif
-          raft::yield();
+         raft::yield();
       }
 
       /**
@@ -470,18 +464,17 @@ protected:
 };
 
 /*********************************
- * INLINE CLASS ALLOC STARTS HERE
+ FOR SHM, ALL CLASSES ARE ALLOCATED INLINE
  *********************************/
-
 template < class T >
 class RingBufferBase<
     T,
-    Type::Heap,
-    typename std::enable_if< inline_class_alloc< T >::value >::type >
-: public RingBufferBaseHeap< T, Type::Heap >
+    Type::SharedMemory,
+    typename std::enable_if< ! inline_nonclass_alloc< T >::value >::type >
+: public RingBufferBaseHeap< T, Type::SharedMemory >
 {
 public:
-   RingBufferBase() : RingBufferBaseHeap< T, Type::Heap >()
+   RingBufferBase() : RingBufferBaseHeap< T, Type::SharedMemory >()
    {
    }
 
@@ -734,13 +727,20 @@ protected:
       if( ptr != nullptr )
       {
           T *item( reinterpret_cast< T* >( ptr ) );
-          new (
+          T * temp( new (
             &buff_ptr->store[ write_index ]
-          ) T( *item  );
+          ) T( *item  ) );
+          UNUSED( temp );
           (this)->producer_data.write_stats->bec.count++;
        }
       buff_ptr->signal[ write_index ]         = signal;
        Pointer::inc( buff_ptr->write_pt );
+#if 0
+      if( signal == raft::quit )
+      {
+         (this)->write_finished = true;
+      }
+#endif      
       (this)->datamanager.exitBuffer( dm::push );
    }
 
@@ -791,13 +791,6 @@ protected:
       /** gotta dereference pointer and copy **/
       T *item( reinterpret_cast< T* >( ptr ) );
       *item = buff_ptr->store[ read_index ];
-      /** 
-       * we know the object is inline constructed, 
-       * we should inline destruct it to fix bug
-       * #76 -jcb 18Nov2018
-       * - applying same fix to out-of-band objects
-       */
-      ( &buff_ptr->store[ read_index ] )->~T();
       /** only increment here b/c we're actually reading an item **/
       (this)->consumer_data.read_stats->bec.count++;
       Pointer::inc( buff_ptr->read_pt );
@@ -906,487 +899,4 @@ protected:
 
 };
 
-/**************************************
- *EXTERNAL ALLOCATE STARTS HERE
- **************************************/
-
-template < class T >
-class RingBufferBase<
-    T,
-    Type::Heap,
-    typename std::enable_if< ext_alloc< T >::value >::type >
-: public RingBufferBaseHeap< T, Type::Heap >
-{
-public:
-   RingBufferBase() : RingBufferBaseHeap< T, Type::Heap >()
-   {
-   }
-
-   virtual ~RingBufferBase() = default;
-
-   virtual void deallocate()
-   {
-      auto * const buff_ptr( (this)->datamanager.get() );
-      const size_t write_index( Pointer::val( buff_ptr->write_pt ) );
-      auto *ptr(
-        reinterpret_cast< T* >( buff_ptr->store[ write_index ] )
-      );
-      /** call local delete on obj **/
-      /** 
-       * bugfix for issue #37, memory leak, copy paste
-       * error resulted in destructor being called, but
-       * no deallocate. - jcb 15 July 2017
-       */
-      delete( ptr );
-      (this)->producer_data.allocate_called = false;
-      (this)->datamanager.exitBuffer( dm::allocate );
-   }
-
-   /**
-    * send- releases the last item allocated by allocate() to
-    * the queue.  Function will imply return if allocate wasn't
-    * called prior to calling this function.
-    * @param signal - const raft::signal signal, default: NONE
-    */
-   virtual void send( const raft::signal signal = raft::none )
-   {
-      if( R_UNLIKELY( ! (this)->producer_data.allocate_called ) )
-      {
-         return;
-      }
-      /** should be the end of the write, regardless of which allocate called **/
-      auto * const buff_ptr( (this)->datamanager.get() );
-      const size_t write_index( Pointer::val( buff_ptr->write_pt ) );
-      buff_ptr->signal[ write_index ] = signal;
-      (this)->producer_data.write_stats->bec.count++;
-      (this)->producer_data.allocate_called = false;
-      Pointer::inc( buff_ptr->write_pt );
-      (this)->datamanager.exitBuffer( dm::allocate );
-   }
-
-   /**
-    * send_range - releases the last item allocated by allocate_range() to
-    * the queue.  Function will imply return if allocate wasn't
-    * called prior to calling this function.
-    * @param signal - const raft::signal signal, default: NONE
-    */
-   virtual void send_range( const raft::signal signal = raft::none )
-   {
-      if( ! (this)->producer_data.allocate_called ) return;
-      /** should be the end of the write, regardless of which allocate called **/
-      const size_t write_index( Pointer::val( (this)->datamanager.get()->write_pt ) );
-      (this)->datamanager.get()->signal[ write_index ] = signal;
-      auto &n_allocated( (this)->producer_data.n_allocated );
-      Pointer::incBy( (this)->datamanager.get()->write_pt,
-                      n_allocated );
-      /** cleanup **/
-      (this)->producer_data.write_stats->bec.count += n_allocated;
-      (this)->producer_data.allocate_called = false;
-      n_allocated     = 0;
-      (this)->datamanager.exitBuffer( dm::allocate_range );
-   }
-
-
-   virtual void unpeek()
-   {
-      (this)->datamanager.exitBuffer( dm::peek );
-   }
-
-protected:
-
-   /**
-    * removes range items from the buffer, ignores
-    * them without the copy overhead.
-    */
-   virtual void local_recycle( std::size_t range )
-   {
-      if( range == 0 )
-      {
-         /** do nothing **/
-         return;
-      }
-      do{ /** at least one to remove **/
-         for( ;; )
-         {
-            (this)->datamanager.enterBuffer( dm::recycle );
-            if( (this)->datamanager.notResizing() )
-            {
-               if( (this)->size() > 0 )
-               {
-                  break;
-               }
-               else if( (this)->is_invalid() && (this)->size() == 0 )
-               {
-                  (this)->datamanager.exitBuffer( dm::recycle );
-                  return;
-               }
-            }
-            (this)->datamanager.exitBuffer( dm::recycle );
-            raft::yield();
-         }
-         auto * const buff_ptr( (this)->datamanager.get() );
-         const size_t read_index( Pointer::val( buff_ptr->read_pt ) );
-
-         auto **ptr( reinterpret_cast< void** >( &( buff_ptr->store[ read_index ] ) )
-         );
-
-         (this)->consumer_data.in->insert(
-            std::make_pair( reinterpret_cast< std::uintptr_t >( *ptr ),
-                            []( void * ptr )
-                            {
-                                auto *actual_ptr(
-                                    reinterpret_cast< T* >( ptr )
-                                );
-                                /** 
-                                 * bugfix for issue #37, memory leak, copy paste
-                                 * error resulted in destructor being called, but
-                                 * no deallocate. - jcb 15 July 2017
-                                 */
-                                delete( actual_ptr );
-                            } ) );
-         Pointer::inc( buff_ptr->read_pt );
-         (this)->datamanager.exitBuffer( dm::recycle );
-      }while( --range > 0 );
-      return;
-   }
-
-
-
-   /**
-    * local_allocate - get a reference to an object of type T at the
-    * end of the queue.  Should be released to the queue using
-    * the push command once the calling thread is done with the
-    * memory.
-    * @return T&, reference to memory location at head of queue
-    */
-   virtual void local_allocate( void **ptr )
-   {
-      for(;;)
-      {
-         (this)->datamanager.enterBuffer( dm::allocate );
-         if( (this)->datamanager.notResizing() && (this)->space_avail() > 0  )
-         {
-            break;
-         }
-         (this)->datamanager.exitBuffer( dm::allocate );
-         /** else, set stats,  spin **/
-         auto &wr_stats( (this)->producer_data.write_stats->bec.blocked );
-         if( wr_stats == 0 )
-         {
-            wr_stats = 1;
-         }
-#if __x86_64
-         __asm__ volatile("\
-           pause"
-           :
-           :
-           : );
-#endif
-         raft::yield();
-      }
-      auto * const buff_ptr( (this)->datamanager.get() );
-      const size_t write_index( Pointer::val( buff_ptr->write_pt ) );
-      *ptr = (void*)&( buff_ptr->store[ write_index ] );
-      (this)->producer_data.allocate_called = true;
-      /** call exitBuffer during push call **/
-   }
-
-   virtual void local_allocate_n( void *ptr, const std::size_t n )
-   {
-      for( ;; )
-      {
-         (this)->datamanager.enterBuffer( dm::allocate_range );
-         if( (this)->datamanager.notResizing() && (this)->space_avail() >= n )
-         {
-            break;
-         }
-         else
-         {
-            (this)->datamanager.exitBuffer( dm::allocate_range );
-         }
-         /** else, set stats,  spin **/
-         auto &wr_stats( (this)->producer_data.write_stats->bec.blocked );
-         if( wr_stats == 0 )
-         {
-            wr_stats = 1;
-         }
-#if __x86_64
-       __asm__ volatile("\
-         pause"
-         :
-         :
-         : );
-#endif
-         raft::yield();
-      }
-      auto *container(
-         reinterpret_cast< std::vector< std::reference_wrapper< T > >* >( ptr ) );
-      /**
-       * TODO, fix this condition where the user can ask for more,
-       * double buffer.
-       */
-      /** iterate over range, pause if not enough items **/
-      auto * const buff_ptr( (this)->datamanager.get() );
-      std::size_t write_index( Pointer::val( buff_ptr->write_pt ) );
-      for( std::size_t index( 0 ); index < n; index++ )
-      {
-         /**
-          * TODO, fix this logic here, write index must get iterated, but
-          * not here
-          */
-         container->emplace_back(
-            *reinterpret_cast< T* >( buff_ptr->store[ write_index ] ) );
-         buff_ptr->signal[ write_index ] = raft::none;
-         write_index = ( write_index + 1 ) % buff_ptr->max_cap;
-      }
-      (this)->producer_data.allocate_called = true;
-      /** exitBuffer() called by push_range **/
-   }
-
-
-   /**
-    * local_push - implements the pure virtual function from the
-    * FIFO interface.  Takes a void ptr as the object which is
-    * cast into the correct form and an raft::signal signal. If
-    * the ptr is null, then the signal is pushed and the item
-    * is junk.  This is an internal method so the only case where
-    * ptr should be null is in the case of a system signal being
-    * sent.
-    * @param   item, void ptr
-    * @param   signal, const raft::signal&
-    */
-   virtual void  local_push( void *ptr, const raft::signal &signal )
-   {
-      for(;;)
-      {
-         (this)->datamanager.enterBuffer( dm::push );
-         if( (this)->datamanager.notResizing() )
-         {
-            if( (this)->space_avail() > 0 )
-            {
-               break;
-            }
-         }
-         (this)->datamanager.exitBuffer( dm::push );
-         auto &wr_stats( (this)->producer_data.write_stats->bec.blocked );
-         if( wr_stats == 0 )
-         {
-            wr_stats = 1;
-         }
-#if __x86_64
-         __asm__ volatile("\
-           pause"
-           :
-           :
-           : );
-#endif
-         raft::yield();
-      }
-      auto * const buff_ptr( (this)->datamanager.get() );
-       const size_t write_index( Pointer::val( buff_ptr->write_pt ) );
-      if( ptr != nullptr )
-      {
-         /** might be faster to simply check stack range for alloc loc **/
-         T *item( reinterpret_cast< T* >( ptr ) );
-         auto **b_ptr( reinterpret_cast< T** >( &buff_ptr->store[ write_index ] ) );
-
-         if( (this)->producer_data.out_peek->find(
-            reinterpret_cast< std::uintptr_t >( item ) ) != 
-                (this)->producer_data.out_peek->cend() )
-         {
-            //this was from a previous peek call
-            (this)->producer_data.out->insert( reinterpret_cast< std::uintptr_t >( item ) );
-            *b_ptr = item;
-         }
-         else /** hope we have a move/copy constructor **/
-         {
-            *b_ptr = new T( *item );
-         }
-         (this)->producer_data.write_stats->bec.count++;
-       }
-      buff_ptr->signal[ write_index ]         = signal;
-       Pointer::inc( buff_ptr->write_pt );
-#if 0       
-      if( signal == raft::quit )
-      {
-         (this)->write_finished = true;
-      }
-#endif      
-      (this)->datamanager.exitBuffer( dm::push );
-   }
-
-   /**
-    * local_pop - read one item from the ring buffer,
-    * will block till there is data to be read.  If
-    * ptr == nullptr then the item is just thrown away.
-    * @return  T, item read.  It is removed from the
-    *          q as soon as it is read
-    */
-   virtual void
-   local_pop( void *ptr, raft::signal *signal )
-   {
-      for(;;)
-      {
-         (this)->datamanager.enterBuffer( dm::pop );
-         if( (this)->datamanager.notResizing() )
-         {
-            if( (this)->size() > 0 )
-            {
-               break;
-            }
-            else if( (this)->is_invalid() && (this)->size() == 0 )
-            {
-               throw ClosedPortAccessException(
-                  "Accessing closed port with pop call, exiting!!" );
-            }
-         }
-         else
-         {
-            (this)->datamanager.exitBuffer( dm::pop );
-            /** handle stats **/
-            auto &rd_stats( (this)->consumer_data.read_stats->bec.blocked );
-            if( rd_stats == 0 )
-            {
-               rd_stats  = 1;
-            }
-            raft::yield();
-         }
-      }
-      auto * const buff_ptr( (this)->datamanager.get() );
-      const std::size_t read_index( Pointer::val( buff_ptr->read_pt ) );
-      if( signal != nullptr )
-      {
-         *signal = buff_ptr->signal[ read_index ];
-      }
-      assert( ptr != nullptr );
-      /** gotta dereference pointer and copy **/
-      T *item( reinterpret_cast< T* >( ptr ) );
-      auto *head( reinterpret_cast< T* >( buff_ptr->store[ read_index ] ) );
-      *item = *head;
-      /** only increment here b/c we're actually reading an item **/
-      (this)->consumer_data.read_stats->bec.count++;
-      Pointer::inc( buff_ptr->read_pt );
-      /**
-       * fix for bug #76 - jcb 18Nov2018
-       */
-      head->~T();
-      (this)->datamanager.exitBuffer( dm::pop );
-   }
-
-
-   /**
-    * local_peek() - look at a reference to the head of the
-    * ring buffer.  This doesn't remove the item, but it
-    * does give the user a chance to take a look at it without
-    * removing.
-    * @return T&
-    */
-   virtual void local_peek(  void **ptr, raft::signal *signal )
-   {
-      for(;;)
-      {
-
-         (this)->datamanager.enterBuffer( dm::peek );
-         if( (this)->datamanager.notResizing() )
-         {
-            if( (this)->size() > 0  )
-            {
-               break;
-            }
-            else if( (this)->is_invalid() && (this)->size() == 0 )
-            {
-               throw ClosedPortAccessException(
-                  "Accessing closed port with local_peek call, exiting!!" );
-            }
-         }
-         (this)->datamanager.exitBuffer( dm::peek );
-#if  __x86_64
-         __asm__ volatile("\
-           pause"
-           :
-           :
-           : );
-#endif
-         raft::yield();
-      }
-      auto * const buff_ptr( (this)->datamanager.get() );
-      const size_t read_index( Pointer::val( buff_ptr->read_pt ) );
-      if( signal != nullptr )
-      {
-         *signal = buff_ptr->signal[ read_index ];
-      }
-      //actual pointer
-      auto ***real_ptr( reinterpret_cast< T*** >( ptr ) );
-      *real_ptr = reinterpret_cast< T** >( &( buff_ptr->store[ read_index ] ) );
-      /** prefetch first 1024  bytes **/
-      //probably need to optimize this for each arch / # of
-      //threads
-      raft::prefetch< raft::READ,
-                      raft::LOTS,
-                      sizeof( T ) < sizeof( std::uintptr_t ) << 7 ?
-                      sizeof( T ) : sizeof( std::uintptr_t ) << 7
-                      >( **real_ptr );
-      (this)->consumer_data.in_peek->insert( reinterpret_cast< ptr_t >( **real_ptr ) );
-      return;
-      /**
-       * exitBuffer() called when recycle is called, can't be sure the
-       * reference isn't being used until all outside accesses to it are
-       * invalidated from the buffer.
-       */
-   }
-
-   virtual void local_peek_range( void **ptr,
-                                  void **sig,
-                                  const std::size_t n,
-                                  std::size_t &curr_pointer_loc )
-   {
-      for(;;)
-      {
-
-         (this)->datamanager.enterBuffer( dm::peek );
-         if( (this)->datamanager.notResizing() )
-         {
-            if( (this)->size() >= n  )
-            {
-               break;
-            }
-            else if( (this)->is_invalid() && (this)->size() == 0 )
-            {
-               (this)->datamanager.exitBuffer( dm::peek );
-               throw ClosedPortAccessException(
-                  "Accessing closed port with local_peek_range call, exiting!!" );
-            }
-            else if( (this)->is_invalid() && (this)->size() < n )
-            {
-               (this)->datamanager.exitBuffer( dm::peek );
-               throw NoMoreDataException( "Too few items left on closed port, kernel exiting" );
-            }
-         }
-         (this)->datamanager.exitBuffer( dm::peek );
-#if  __x86_64
-         __asm__ volatile("\
-           pause"
-           :
-           :
-           : );
-#endif
-         raft::yield();
-      }
-
-      /**
-       * TODO, fix this condition where the user can ask for more,
-       * double buffer.
-       */
-      /** iterate over range, pause if not enough items **/
-      auto * const buff_ptr( (this)->datamanager.get() );
-      const auto cpl( Pointer::val( buff_ptr->read_pt ) );
-      curr_pointer_loc = cpl;
-      *sig =  reinterpret_cast< void* >(  &buff_ptr->signal[ cpl ] );
-      *ptr =  buff_ptr->store;
-      return;
-   }
-
-
-};
-
-#endif /* END RAFTRINGBUFFERHEAP_TCC */
+#endif /* END RAFTRINGBUFFERSHM_TCC */

--- a/raftinc/ringbuffertypes.hpp
+++ b/raftinc/ringbuffertypes.hpp
@@ -1,7 +1,12 @@
-#ifndef RAFTRINGBUFFERTYPES 
-#define RAFTRINGBUFFERTYPES 1
+#ifndef RAFTRINGBUFFERTYPES_HPP 
+#define RAFTRINGBUFFERTYPES_HPP 1
+
 namespace Type{
-   enum RingBufferType { Heap, SharedMemory, TCP, Infinite, N_TYPE};
+   enum RingBufferType { Heap, 
+                         SharedMemory, 
+                         TCP, 
+                         Infinite, 
+                         N };
 }
    
    enum Direction { Producer, Consumer };

--- a/raftinc/sysschedutil.hpp
+++ b/raftinc/sysschedutil.hpp
@@ -20,7 +20,7 @@
 #ifndef RAFTSYSSCHEDUTIL_HPP
 #define RAFTSYSSCHEDUTIL_HPP  1
 
-#if (not defined _WIN64 ) || (not defined _WIN32)
+#if (! defined _WIN64) || (! defined _WIN32)
 #ifdef USEQTHREADS
 #include <qthread/qthread.hpp>
 #else
@@ -39,7 +39,7 @@ namespace raft
 static inline void yield()
 {
 
-#if (not defined _WIN64 ) || (not defined _WIN32)
+#if (! defined _WIN64) || (! defined _WIN32)
 #ifdef USEQTHREADS
     qthread_yield();
 #else         

--- a/raftinc/sysschedutil.hpp
+++ b/raftinc/sysschedutil.hpp
@@ -20,7 +20,7 @@
 #ifndef RAFTSYSSCHEDUTIL_HPP
 #define RAFTSYSSCHEDUTIL_HPP  1
 
-#if (! defined _WIN64) || (! defined _WIN32)
+#if (! defined _WIN64) && (! defined _WIN32)
 #ifdef USEQTHREADS
 #include <qthread/qthread.hpp>
 #else
@@ -39,7 +39,7 @@ namespace raft
 static inline void yield()
 {
 
-#if (! defined _WIN64) || (! defined _WIN32)
+#if (! defined _WIN64) && (! defined _WIN32)
 #ifdef USEQTHREADS
     qthread_yield();
 #else         

--- a/raftinc/sysschedutil.hpp
+++ b/raftinc/sysschedutil.hpp
@@ -20,11 +20,13 @@
 #ifndef RAFTSYSSCHEDUTIL_HPP
 #define RAFTSYSSCHEDUTIL_HPP  1
 
+#if (defined _WIN64 ) || (defined _WIN32)
 #ifdef USEQTHREADS
 #include <qthread/qthread.hpp>
 #else
 #include <sched.h>
 #endif
+#endif /** end if not win **/
 
 namespace raft
 {
@@ -36,11 +38,14 @@ namespace raft
  */
 static inline void yield()
 {
+
+#if (defined _WIN64 ) || (defined _WIN32)
 #ifdef USEQTHREADS
     qthread_yield();
 #else         
     sched_yield();
 #endif
+#endif /** end if not win **/
     return;
 }
 

--- a/raftinc/sysschedutil.hpp
+++ b/raftinc/sysschedutil.hpp
@@ -1,9 +1,9 @@
 /**
- * portorder.hpp - 
+ * sysschedutil.hpp - 
  * @author: Jonathan Beard
- * @version: Wed Mar 16 13:11:49 2016
+ * @version: Mon May 25 09:11:32 2020
  * 
- * Copyright 2016 Jonathan Beard
+ * Copyright 2020 Jonathan Beard
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,17 +17,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef RAFTPORTORDER_HPP
-#define RAFTPORTORDER_HPP  1
-#include <cstdint>
+#ifndef RAFTSYSSCHEDUTIL_HPP
+#define RAFTSYSSCHEDUTIL_HPP  1
+
+#ifdef USEQTHREADS
+#include <qthread/qthread.hpp>
+#else
+#include <sched.h>
+#endif
 
 namespace raft
 {
 
-namespace order
+/**
+ * yield - generic yield function for whatever the underlying
+ * implementation is, could be qthreads, a process, or a thread
+ * but it'll call the right implementation for you. 
+ */
+static inline void yield()
 {
-    enum spec : std::uint8_t { in = 0, out = 1 };
+#ifdef USEQTHREADS
+    qthread_yield();
+#else         
+    sched_yield();
+#endif
+    return;
 }
 
 } /** end namespace raft **/
-#endif /* END RAFTPORTORDER_HPP */
+
+#endif /* END RAFTSYSSCHEDUTIL_HPP */

--- a/raftinc/sysschedutil.hpp
+++ b/raftinc/sysschedutil.hpp
@@ -20,7 +20,7 @@
 #ifndef RAFTSYSSCHEDUTIL_HPP
 #define RAFTSYSSCHEDUTIL_HPP  1
 
-#if (defined _WIN64 ) || (defined _WIN32)
+#if (not defined _WIN64 ) || (not defined _WIN32)
 #ifdef USEQTHREADS
 #include <qthread/qthread.hpp>
 #else
@@ -39,7 +39,7 @@ namespace raft
 static inline void yield()
 {
 
-#if (defined _WIN64 ) || (defined _WIN32)
+#if (not defined _WIN64 ) || (not defined _WIN32)
 #ifdef USEQTHREADS
     qthread_yield();
 #else         

--- a/raftinc/threadaccess.hpp
+++ b/raftinc/threadaccess.hpp
@@ -1,0 +1,79 @@
+/**
+ * threadaccess.hpp - 
+ * @author: Jonathan Beard
+ * @version: Sun Oct 30 04:58 2016
+ * 
+ * Copyright 2016 Jonathan Beard
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef RAFTTHREADACCESS_HPP
+#define RAFTTHREADACCESS_HPP  1
+#include <cstdint>
+#include "defs.hpp"
+#include "internaldefs.hpp"
+
+namespace dm
+{
+
+using key_t = raft::byte_t;
+
+/**
+ * access_key - each one of these is to be used as a 
+ * key for  buffer access functions.  Everything <= 
+ * push is expected to be a write type function, everything
+ * else is expected to be a read type operation.
+ */
+enum access_key : key_t { allocate       = 0, 
+                          allocate_range = 1, 
+                          push           = 3, 
+                          recycle        = 4, 
+                          pop            = 5, 
+                          peek           = 6, 
+                          size           = 7,
+                          N };
+}
+
+struct ALIGN( L1D_CACHE_LINE_SIZE ) ThreadAccess
+{
+    ThreadAccess() = default;
+
+    constexpr ThreadAccess( const ThreadAccess  &other )
+    {
+        (this)->whole = other.whole;
+    }
+    
+    constexpr ThreadAccess& operator = (const ThreadAccess &other ) noexcept
+    {
+        /** ignore the case of 'this' == other **/
+        (this)->whole = other.whole;
+        return( *this );
+    }
+    
+    /** 
+     * technically not needed but this makes debugging
+     * a bit easier. - jcb July 2019
+     */
+    ~ThreadAccess(){ (this)->whole = 0; }
+
+    union
+    {
+        std::uint64_t whole = 0;
+        dm::key_t     flag[ 8 ];
+    };
+
+    raft::byte_t    padding[ L1D_CACHE_LINE_SIZE - 8 /** padd to cache line **/ ]   = {};
+};
+
+
+#endif /* END RAFTTHREADACCESS_HPP */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(CPP_SRC_FILES 
     allocate.cpp
     basicparallel.cpp
+    blocked.cpp
     common.cpp
     dynalloc.cpp
     fifo.cpp

--- a/src/allocate.cpp
+++ b/src/allocate.cpp
@@ -73,9 +73,7 @@ Allocate::initialize( PortInfo * const src,
          "Destination port \"" + dst->my_name +  "\" already initialized!" );
    }
    src->setFIFO( fifo );
-   fifo->set_src_kernel( src->my_kernel );
    dst->setFIFO( fifo );
-   fifo->set_dst_kernel( dst->my_kernel );
    /** NOTE: this list simply speeds up the monitoring if we want it **/
    allocated_fifo.insert( fifo );
 }
@@ -84,8 +82,7 @@ Allocate::initialize( PortInfo * const src,
 void
 Allocate::allocate( PortInfo &a, PortInfo &b, void *data )
 {
-   (void) data;
-
+   UNUSED( data );
    FIFO *fifo( nullptr );
    auto &func_map( a.const_map[ Type::Heap ] );
    auto test_func( (*func_map)[ false ] );

--- a/src/blocked.cpp
+++ b/src/blocked.cpp
@@ -1,0 +1,40 @@
+/**
+ * blocked.cpp - 
+ * @author: Jonathan Beard
+ * @version: Mon Apr  3 12:06:50 2017
+ * 
+ * Copyright 2017 Jonathan Beard
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "blocked.hpp"
+
+Blocked::Blocked()
+{
+
+}
+
+Blocked::Blocked( const Blocked &other ) : all( other.all )
+{
+    /** nothing to do here either **/
+}
+
+Blocked&
+Blocked::operator += ( const Blocked &rhs ) noexcept
+{
+    if( ! rhs.bec.blocked )
+    {
+        (this)->bec.count += rhs.bec.count;
+    }
+    return( (*this) );
+}

--- a/src/kpair.cpp
+++ b/src/kpair.cpp
@@ -2,7 +2,6 @@
 
 #include "kpair.hpp"
 #include "kernel.hpp"
-#include "portorder.hpp"
 #include "kernel_wrapper.hpp"
 
 kpair::kpair( raft::kernel &a, 

--- a/src/pointer.cpp
+++ b/src/pointer.cpp
@@ -26,67 +26,96 @@ Pointer::Pointer(const std::size_t cap,
                  const wrap_t wrap_set ) : Pointer( cap )
 {
     wrap_a = wrap_set;
+#ifdef JVEC_MACHINE
     wrap_b = wrap_set;
+#endif    
 }
 
 
-Pointer::Pointer( Pointer * const other, 
+Pointer::Pointer( Pointer &other, 
                   const std::size_t new_cap ) : Pointer( new_cap )
 {
-   const auto val(  Pointer::val( other ) );
-   a = val;
-   b = val;
+    const auto val(  Pointer::val( other ) );
+    a = val;
+#ifdef JVEC_MACHINE
+    b = val;
+#endif
+    return;
 }
 
 std::size_t 
-Pointer::val( Pointer * const ptr ) 
+Pointer::val( Pointer &ptr ) 
 {
+#ifdef JVEC_MACHINE
    struct{
       std::uint64_t a;
       std::uint64_t b;
    }copy;
    do{
-      copy.a = ptr->a;
-      copy.b = ptr->b;
+      copy.a = ptr.a;
+      copy.b = ptr.b;
    }while( copy.a !=  copy.b );
    return( copy.b );
+#else
+   return( ptr.a );
+#endif
 }
 
 void
-Pointer::inc( Pointer * const ptr ) 
+Pointer::inc( Pointer &ptr ) 
 {
-   ptr->a = ( ptr->a + 1 ) % ptr->max_cap;
-   ptr->b = ( ptr->b + 1 ) % ptr->max_cap;
-   if( ptr->b == 0 )
+#ifdef JVEC_MACHINE
+   ptr.a = ( ptr.a + 1 ) % ptr.max_cap;
+   ptr.b = ( ptr.b + 1 ) % ptr.max_cap;
+   if( ptr.b == 0 )
    {
-      ptr->wrap_a++;
-      ptr->wrap_b++;
+      ptr.wrap_a++;
+      ptr.wrap_b++;
    }
+#else
+   ptr.a = ( ptr.a + 1 ) % ptr.max_cap;
+   if( ptr.a == 0 )
+   {
+      ptr.wrap_a++;
+   }
+#endif
 }
 
 void
-Pointer::incBy( Pointer * const ptr, 
+Pointer::incBy( Pointer &ptr, 
                 const std::size_t in )
 {
-   ptr->a = ( ptr->a + in ) % ptr->max_cap;
-   ptr->b = ( ptr->b + in ) % ptr->max_cap;
-   if( ptr->b < in )
+#ifdef JVEC_MACHINE
+   ptr.a = ( ptr.a + in ) % ptr.max_cap;
+   ptr.b = ( ptr.b + in ) % ptr.max_cap;
+   if( ptr.b < in )
    {
-      ptr->wrap_a++;
-      ptr->wrap_b++;
+      ptr.wrap_a++;
+      ptr.wrap_b++;
    }
+#else
+   ptr.a = ( ptr.a + in ) % ptr.max_cap;
+   if( ptr.a < in )
+   {
+      ptr.wrap_a++;
+   }
+#endif
 }
 
 std::size_t 
-Pointer::wrapIndicator( Pointer * const ptr ) 
+Pointer::wrapIndicator( Pointer &ptr ) 
 {
-   struct{
-      std::uint64_t a;
-      std::uint64_t b;
-   }copy;
-   do{
-      copy.a = ptr->wrap_a;
-      copy.b = ptr->wrap_b;
-   }while( copy.a != copy.b );
-   return( copy.b );
+#ifdef JVEC_MACHINE
+    struct{
+       std::uint64_t a;
+       std::uint64_t b;
+    }copy;
+    do{
+       copy.a = ptr.wrap_a;
+       copy.b = ptr.wrap_b;
+    }while( copy.a != copy.b );
+    return( copy.b );
+#else
+    return( ptr.wrap_a );
+#endif
 }

--- a/src/raftexception.cpp
+++ b/src/raftexception.cpp
@@ -25,7 +25,7 @@
 
 RaftException::RaftException( const std::string message ) : 
     message( 
-#elif (defined _WIN64 ) || (defined _WIN32) 
+#if (defined _WIN64 ) || (defined _WIN32) 
     /**
      * fix for warning C4996: 'strdup': The POSIX name for this item is
      * a bit annoying given it is a POSIX function, but this is the best

--- a/src/raftexception.cpp
+++ b/src/raftexception.cpp
@@ -3,7 +3,7 @@
  * @author: Jonathan Beard
  * @version: Fri Dec 23 13:59:44 2016
  * 
- * Copyright 2016 Jonathan Beard
+ * Copyright 2020 Jonathan Beard
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
 #include "raftexception.hpp"
 
 RaftException::RaftException( const std::string message ) : 
-    message( strdup( message.c_str() ) )
+    message( std::strdup( message.c_str() ) )
 {
 }
 

--- a/src/raftexception.cpp
+++ b/src/raftexception.cpp
@@ -24,7 +24,18 @@
 #include "raftexception.hpp"
 
 RaftException::RaftException( const std::string message ) : 
-    message( std::strdup( message.c_str() ) )
+    message( 
+#elif (defined _WIN64 ) || (defined _WIN32) 
+    /**
+     * fix for warning C4996: 'strdup': The POSIX name for this item is
+     * a bit annoying given it is a POSIX function, but this is the best
+     * we can do, see: https://bit.ly/2TH0Jci
+     */
+    _strdup( message.c_str() )
+#else //everybody else
+    strdup( message.c_str() ) 
+#endif
+    )
 {
 }
 

--- a/src/sysschedutil.cpp
+++ b/src/sysschedutil.cpp
@@ -1,0 +1,38 @@
+/**
+ * sysschedutil.cpp - 
+ * @author: Jonathan Beard
+ * @version: Mon May 25 09:11:32 2020
+ * 
+ * Copyright 2020 Jonathan Beard
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "sysschedutil.hpp"
+
+#ifdef USEQTHREADS
+#include <qthread/qthread.hpp>
+#else
+#include <sched.h>
+#endif
+
+void 
+raft::yield()
+{
+#ifdef USEQTHREADS
+    qthread_yield();
+#else         
+    sched_yield();
+#endif
+    return;
+}


### PR DESCRIPTION
In progress, will set to draft momentarily. 

## In this pull request
* changes for the fifo, ringbuffers, blocked structures
* aim is to make all structures with the ringbuffer compatible 
once again with shared memory so we can go back to multiprocess
in addition to multi-thread. 
* changes should also make it amenable to make the fifo itself a module, and 
therefore be able to insert whatever FIFOs we want to (e.g. #zeromq, https://github.com/zeromq/libzmq) and boostfifo, even MPI with wrappers. 

@f-tischler, could you look over chances with an eye towards win, I'm gonna double check momentarily to make doubly sure I didn't miss any Win specific guards that were supposed to be in place. 