### PR TITLE
added reference overload for operator[] in response to a bug

### DIFF
--- a/raftinc/kernel.hpp
+++ b/raftinc/kernel.hpp
@@ -114,10 +114,12 @@ public:
    /**
     * operator[] - returns the current kernel with the 
     * specified port name enabled for linking.
-    * @param portname - const std::string&&
+    * @param portname - const raft::port_key_type&&
     * @return raft::kernel&&
     */
    raft::kernel& operator []( const std::string &&portname );
+   raft::kernel& operator []( const std::string &portname );
+
 
    core_id_t getCoreAssignment() noexcept
    {

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -29,8 +29,25 @@ kernel::get_id()
    return( kernel_id );
 }
 
+
 raft::kernel&
 kernel::operator []( const std::string &&portname )
+{
+   if( enabled_port.size() < 2 )
+   {
+        enabled_port.push( portname );
+   }
+   else
+   {
+        throw AmbiguousPortAssignmentException(
+            "too many ports added with: " + portname
+        );
+   }
+   return( (*this) );
+}
+
+raft::kernel&
+kernel::operator []( const std::string &portname )
 {
    if( enabled_port.size() < 2 )
    {


### PR DESCRIPTION
## Description

Fix that enables references to be used for port name, was fixed on dev branch, just not on the local one, technically I still need to add a test cases as well specifically for this. 

Fixes # (issue)
[link to gist with bug annotated](https://gist.github.com/woodjamesdee/868c98d9c9723b6fa6e70ffa9baa5592)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Runs locally on Windows
- [x] Runs locally on Linux
- [x] Runs locally on OS X

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
