### PR TITLE
fixed cmake build linking for examples

### DIFF
--- a/examples/cppalgo/search/CMakeLists.txt
+++ b/examples/cppalgo/search/CMakeLists.txt
@@ -1,29 +1,18 @@
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake )
 
 find_package( Threads )
-##
-# check for Scotch, use if there
-##
-find_package( Scotch )
-##
-# c/c++ std
-##
-include( CheckSTD )
-
-find_package( LIBRT )
-
 
 set( APP bmh )
 
 add_executable( ${APP} "${APP}.cpp" )
 
-include_directories( ${CMAKE_SCOTCH_INCS} )
 
 target_link_libraries( ${APP} 
                        raft                       
+                       demangle
+                       affinity
                        ${CMAKE_THREAD_LIBS_INIT} 
-                       ${CMAKE_SCOTCH_LIBS}
-                       ${CMAKE_RT_LIBS}
+                       ${CMAKE_QTHREAD_LIBS}
                        )
 
 file( COPY alice.txt

--- a/examples/general/multiply/CMakeLists.txt
+++ b/examples/general/multiply/CMakeLists.txt
@@ -1,45 +1,14 @@
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake )
 
-find_package( Threads )
-##
-# check for Scotch, use if there
-##
-find_package( Scotch )
-##
-# c/c++ std
-##
-include( CheckSTD )
-find_package( LIBRT )
-
-set( GITDEP "${CMAKE_SOURCE_DIR}/git-dep" )
-##
-# grab include directories for git-dep
-##
-if( EXISTS ${GITDEP} )
-##
-# get the dirs that are in the git-dep folder
-##
-file( GLOB DEPFOLDERLIST ${GITDEP}/* )
-foreach( DEPFOLDER ${DEPFOLDERLIST} )
-    message( STATUS "Checking: ${DEPFOLDER}" )
-    if( IS_DIRECTORY ${DEPFOLDER} )
-        message( STATUS "Found: ${DEPFOLDER}" )
-        include_directories( ${DEPFOLDER}/include )
-        link_directories( ${DEPFOLDER}/lib )
-    endif( IS_DIRECTORY ${DEPFOLDER} )
-endforeach( DEPFOLDER ${DEPFOLDERLIST} )
-
-endif( EXISTS ${GITDEP} )
-
 set( APP multapp )
 
 add_executable( ${APP} "${APP}.cpp" )
 
-include_directories( ${CMAKE_SCOTCH_INCS} )
 
 target_link_libraries( ${APP} 
-                       raft
+                       raft                       
+                       demangle
+                       affinity
                        ${CMAKE_THREAD_LIBS_INIT} 
-                       ${CMAKE_SCOTCH_LIBS}
-                       ${CMAKE_RT_LIBS} )
-
+                       ${CMAKE_QTHREAD_LIBS}
+                       )

--- a/examples/general/pi/CMakeLists.txt
+++ b/examples/general/pi/CMakeLists.txt
@@ -1,46 +1,16 @@
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake )
 
-find_package( Threads )
-##
-# check for Scotch, use if there
-##
-find_package( Scotch )
-##
-# c/c++ std
-##
-include( CheckSTD )
-find_package( LIBRT )
-
-set( GITDEP "${CMAKE_SOURCE_DIR}/git-dep" )
-##
-# grab include directories for git-dep
-##
-if( EXISTS ${GITDEP} )
-##
-# get the dirs that are in the git-dep folder
-##
-file( GLOB DEPFOLDERLIST ${GITDEP}/* )
-foreach( DEPFOLDER ${DEPFOLDERLIST} )
-    message( STATUS "Checking: ${DEPFOLDER}" )
-    if( IS_DIRECTORY ${DEPFOLDER} )
-        message( STATUS "Found: ${DEPFOLDER}" )
-        include_directories( ${DEPFOLDER}/include )
-        link_directories( ${DEPFOLDER}/lib )
-    endif( IS_DIRECTORY ${DEPFOLDER} )
-endforeach( DEPFOLDER ${DEPFOLDERLIST} )
-
-endif( EXISTS ${GITDEP} )
-
-include_directories( ${CMAKE_SCOTCH_INCS} )
 
 set( APP pisim )
 
 add_executable( ${APP} "${APP}.cpp" )
 
-target_link_libraries( ${APP} 
-                       raft
-                       cmdargs
-                       ${CMAKE_SCOTCH_LIBS}
-                       ${CMAKE_THREAD_LIBS_INIT} 
-                       ${CMAKE_RT_LIBS} )
 
+target_link_libraries( ${APP} 
+                       raft                       
+                       demangle
+                       cmdargs
+                       affinity
+                       ${CMAKE_THREAD_LIBS_INIT} 
+                       ${CMAKE_QTHREAD_LIBS}
+                       )

--- a/examples/general/rbzip2/CMakeLists.txt
+++ b/examples/general/rbzip2/CMakeLists.txt
@@ -1,49 +1,21 @@
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake )
 
-find_package( Threads )
-##
-# check for Scotch, use if there
-##
-find_package( Scotch )
-##
-# c/c++ std
-##
-include( CheckSTD )
-find_package( LIBRT )
 find_package( BZip2 REQUIRED)
-
-set( GITDEP "${CMAKE_SOURCE_DIR}/git-dep" )
-##
-# grab include directories for git-dep
-##
-if( EXISTS ${GITDEP} )
-##
-# get the dirs that are in the git-dep folder
-##
-file( GLOB DEPFOLDERLIST ${GITDEP}/* )
-foreach( DEPFOLDER ${DEPFOLDERLIST} )
-    message( STATUS "Checking: ${DEPFOLDER}" )
-    if( IS_DIRECTORY ${DEPFOLDER} )
-        message( STATUS "Found: ${DEPFOLDER}" )
-        include_directories( ${DEPFOLDER}/include )
-        link_directories( ${DEPFOLDER}/lib )
-    endif( IS_DIRECTORY ${DEPFOLDER} )
-endforeach( DEPFOLDER ${DEPFOLDERLIST} )
-
-endif( EXISTS ${GITDEP} )
 
 set( APP rbzip2 )
 
 add_executable( ${APP} "${APP}.cpp" )
-include_directories( ${CMAKE_SCOTCH_INCS} )
+
 
 target_link_libraries( ${APP} 
-                       raft
+                       raft                       
+                       demangle
+                       affinity
                        cmdargs
                        ${BZIP2_LIBRARIES}
-                       ${CMAKE_SCOTCH_LIBS}
                        ${CMAKE_THREAD_LIBS_INIT} 
-                       ${CMAKE_RT_LIBS} )
+                       ${CMAKE_QTHREAD_LIBS}
+                       )
 
 file( COPY alice.txt
       DESTINATION ${CMAKE_CURRENT_BINARY_DIR} )

--- a/examples/general/readfile/CMakeLists.txt
+++ b/examples/general/readfile/CMakeLists.txt
@@ -1,44 +1,13 @@
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake )
 
-find_package( Threads )
-##
-# check for Scotch, use if there
-##
-find_package( Scotch )
-##
-# c/c++ std
-##
-include( CheckSTD )
-find_package( LIBRT )
-
-set( GITDEP "${CMAKE_SOURCE_DIR}/git-dep" )
-##
-# grab include directories for git-dep
-##
-if( EXISTS ${GITDEP} )
-##
-# get the dirs that are in the git-dep folder
-##
-file( GLOB DEPFOLDERLIST ${GITDEP}/* )
-foreach( DEPFOLDER ${DEPFOLDERLIST} )
-    message( STATUS "Checking: ${DEPFOLDER}" )
-    if( IS_DIRECTORY ${DEPFOLDER} )
-        message( STATUS "Found: ${DEPFOLDER}" )
-        include_directories( ${DEPFOLDER}/include )
-        link_directories( ${DEPFOLDER}/lib )
-    endif( IS_DIRECTORY ${DEPFOLDER} )
-endforeach( DEPFOLDER ${DEPFOLDERLIST} )
-
-endif( EXISTS ${GITDEP} )
-
 set( APP readtest)
 
 add_executable( ${APP} "${APP}.cpp" )
-include_directories( ${CMAKE_SCOTCH_INCS} )
 
 target_link_libraries( ${APP} 
-                       raft
-                       ${CMAKE_SCOTCH_LIBS}
+                       raft                       
+                       demangle
+                       affinity
                        ${CMAKE_THREAD_LIBS_INIT} 
-                       ${CMAKE_RT_LIBS} )
-
+                       ${CMAKE_QTHREAD_LIBS}
+                       )

--- a/examples/general/singlequeue/CMakeLists.txt
+++ b/examples/general/singlequeue/CMakeLists.txt
@@ -1,44 +1,13 @@
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake )
 
-find_package( Threads )
-##
-# check for Scotch, use if there
-##
-find_package( Scotch )
-##
-# c/c++ std
-##
-include( CheckSTD )
-find_package( LIBRT )
-
-set( GITDEP "${CMAKE_SOURCE_DIR}/git-dep" )
-##
-# grab include directories for git-dep
-##
-if( EXISTS ${GITDEP} )
-##
-# get the dirs that are in the git-dep folder
-##
-file( GLOB DEPFOLDERLIST ${GITDEP}/* )
-foreach( DEPFOLDER ${DEPFOLDERLIST} )
-    message( STATUS "Checking: ${DEPFOLDER}" )
-    if( IS_DIRECTORY ${DEPFOLDER} )
-        message( STATUS "Found: ${DEPFOLDER}" )
-        include_directories( ${DEPFOLDER}/include )
-        link_directories( ${DEPFOLDER}/lib )
-    endif( IS_DIRECTORY ${DEPFOLDER} )
-endforeach( DEPFOLDER ${DEPFOLDERLIST} )
-
-endif( EXISTS ${GITDEP} )
-
 set( APP singlequeue )
 
 add_executable( ${APP} "${APP}.cpp" )
-include_directories( ${CMAKE_SCOTCH_INCS} )
 
 target_link_libraries( ${APP} 
-                       raft
+                       raft                       
+                       demangle
+                       affinity
                        ${CMAKE_THREAD_LIBS_INIT} 
-                       ${CMAKE_SCOTCH_LIBS}
-                       ${CMAKE_RT_LIBS} )
-
+                       ${CMAKE_QTHREAD_LIBS}
+                       )

--- a/examples/general/sum/CMakeLists.txt
+++ b/examples/general/sum/CMakeLists.txt
@@ -1,44 +1,14 @@
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake )
 
-find_package( Threads )
-##
-# check for Scotch, use if there
-##
-find_package( Scotch )
-##
-# c/c++ std
-##
-include( CheckSTD )
-find_package( LIBRT )
-
-set( GITDEP "${CMAKE_SOURCE_DIR}/git-dep" )
-##
-# grab include directories for git-dep
-##
-if( EXISTS ${GITDEP} )
-##
-# get the dirs that are in the git-dep folder
-##
-file( GLOB DEPFOLDERLIST ${GITDEP}/* )
-foreach( DEPFOLDER ${DEPFOLDERLIST} )
-    message( STATUS "Checking: ${DEPFOLDER}" )
-    if( IS_DIRECTORY ${DEPFOLDER} )
-        message( STATUS "Found: ${DEPFOLDER}" )
-        include_directories( ${DEPFOLDER}/include )
-        link_directories( ${DEPFOLDER}/lib )
-    endif( IS_DIRECTORY ${DEPFOLDER} )
-endforeach( DEPFOLDER ${DEPFOLDERLIST} )
-
-endif( EXISTS ${GITDEP} )
 
 set( APP sumapp )
 
 add_executable( ${APP} "${APP}.cpp" )
-include_directories( ${CMAKE_SCOTCH_INCS} )
 
 target_link_libraries( ${APP} 
-                       raft
+                       raft                       
+                       demangle
+                       affinity
                        ${CMAKE_THREAD_LIBS_INIT} 
-                       ${CMAKE_SCOTCH_LIBS}
-                       ${CMAKE_RT_LIBS} )
-
+                       ${CMAKE_QTHREAD_LIBS}
+                       )

--- a/examples/simple/poc.cpp
+++ b/examples/simple/poc.cpp
@@ -109,7 +109,6 @@ int main()
 
     raft::map m;
     
-    // m += a >> b; // Core dump
     m += a >> b >> c;
 
     m.exe();

--- a/examples/simple/sender.cpp
+++ b/examples/simple/sender.cpp
@@ -106,7 +106,6 @@ int  main()
 
     raft::map m;
     
-    // m += a >> b; // Core dump
     m += a >> b >> c;
 
     m.exe();

--- a/examples/simple/twoport.cpp
+++ b/examples/simple/twoport.cpp
@@ -106,7 +106,6 @@ int  main()
 
     raft::map m;
     
-    // m += a >> b; // Core dump
     m += a >> b >> c;
 
     m.exe();


### PR DESCRIPTION
## Description

When creating the new build system, the examples weren't updated. This pull request 
corrects the linking order for the examples when building with ```-DBUILD_EXAMPLES=1```.
We still need to build in test cases for the examples at some point...but, this will at least
correct the original oversight. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Runs locally on Windows
- [x] Runs locally on Linux
- [x] Runs locally on OS X

### Details

Please list details of the configurations of above local tests, specifically 
relevant run details.

###
 
**No new test cases added, compiled on Linux, OS X and ran examples**

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
