### PR TITLE
fix for cmake pkg-config not including right flags for external compile

### DIFF
--- a/cmake/FindQThreads.cmake
+++ b/cmake/FindQThreads.cmake
@@ -39,7 +39,8 @@ if( QTHREAD_LIBRARY )
     set( CMAKE_QTHREAD_LIBS  "-lqthread" )
     set( CMAKE_QTHREAD_INCS "-I${QTHREAD_INCLUDE}" )
     #set compilation to actually compile qthread
-    add_definitions( "-DUSEQTHREADS=1" )
+    set( CMAKE_QTHREAD_FLAGS "-DUSEQTHREADS=1" )
+    add_definitions( ${CMAKE_QTHREAD_FLAGS} )
     message( STATUS "Using Qthread threading library" ) 
     message( STATUS "LIBRARY: ${QTHREAD_LIBRARY}" ) 
     message( STATUS "INCLUDE: ${QTHREAD_INCLUDE}" ) 
@@ -54,6 +55,7 @@ else( ${USEQTHREAD} )
     
     set( CMAKE_QTHREAD_LIBS "" )
     set( CMAKE_QTHREAD_INCS "" )
+    set( CMAKE_QTHREAD_FLAGS "" )
 
 endif( ${USEQTHREAD} )
 

--- a/raftlib.pc.in
+++ b/raftlib.pc.in
@@ -10,4 +10,4 @@ Requires: shm affinity demangle cmdargs
 Conflicts: 
 Libs:  -L${libdir} -lraft @CMAKE_QTHREAD_LDFLAGS@ @CMAKE_QTHREAD_LIBS@ @CMAKE_THREAD_LIBS_INIT@ @CMAKE_RT_LINK@ 
 Libs.private: shm affinity demangle cmdargs
-Cflags:  -std=c++14 -DL1D_CACHE_LINE_SIZE=@L1D_LINE_SIZE@ -I${includedir} @CMAKE_QTHREAD_INCS@
+Cflags:  -std=c++14 -DL1D_CACHE_LINE_SIZE=@L1D_LINE_SIZE@ -I${includedir} @CMAKE_QTHREAD_INCS@ @CMAKE_QTHREAD_FLAGS@


### PR DESCRIPTION
## Description

Fix for pkg-config file when using qthreads on external build. Looks like a flag
wasn't included. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Runs locally on Windows
- [x] Runs locally on Linux
- [x] Runs locally on OS X

### Details

Please list details of the configurations of above local tests, specifically 
relevant run details.

###
 
Please list test cases created to ensure your feature or addition
works. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
