### PR TITLE
updates to fix multi-input print

### DIFF
--- a/raftinc/kernel.hpp
+++ b/raftinc/kernel.hpp
@@ -161,8 +161,9 @@ protected:
 
     /**
      * NOTE: doesn't need to be atomic since only one thread
-     * will have responsibility to to create new compute 
-     * kernels.
+     * per process will have responsibility to to create new 
+     * compute kernels, for multi-process, this is used in 
+     * conjunction with process identifier.
      */
     static std::size_t kernel_count;
      

--- a/raftinc/kpair.hpp
+++ b/raftinc/kpair.hpp
@@ -150,6 +150,8 @@ kpair& operator <= ( raft::kernel_wrapper &&a, raft::kernel_wrapper &&b );
 kpair& operator <= ( raft::kernel &a,  kpair &b );
 kpair& operator <= ( raft::kernel_wrapper &&w, kpair &b );
 
+kpair& operator >= ( raft::kernel &a, raft::kernel &b );
+kpair& operator >= ( raft::kernel_wrapper &&a, raft::kernel_wrapper &&b );
 kpair& operator >= ( kpair &a, raft::kernel &b );
 kpair& operator >= ( kpair &a, raft::kernel_wrapper &&w );
 kpair& operator >= ( kpair &a, kpair &b );

--- a/raftinc/print.tcc
+++ b/raftinc/print.tcc
@@ -25,7 +25,6 @@
 #include <iostream>
 #include <raft>
 #include <cstdlib>
-#include <mutex>
 
 namespace raft{
 
@@ -33,114 +32,134 @@ class printbase
 {
 protected:
    std::ostream *ofs = nullptr;
-   static std::mutex   print_lock;
 };
 
-std::mutex printbase::print_lock;
 
 template< typename T > class printabstract : public raft::kernel, 
                                              public raft::printbase
 {
 public:
-   printabstract( ) : raft::kernel(),
-                      raft::printbase()
-   {
-      input.addPort< T >( "in" );
-      ofs = &(std::cout);
-   }
-   
-   printabstract( std::ostream &stream ) : raft::kernel(),
-                                           raft::printbase()
-   {
-      input.addPort< T >( "in" );
-      ofs = &stream;
-   }
+    printabstract( const std::size_t n_input_ports = 1 ) : raft::kernel(),
+                                                           raft::printbase()
+    {
+        using index_type = std::remove_const_t< decltype( n_input_ports ) >;
+        for( index_type index( 0 ); index < n_input_ports; index++ )
+        {
+           /** add a port for each index var, all named "input_#" **/
+           input.addPort< T  >( std::to_string( index ) );
+        }
+        ofs = &(std::cout);
+    }
+    
+    printabstract( std::ostream &stream, 
+                   const std::size_t n_input_ports = 1 )  : raft::kernel(),
+                                                            raft::printbase()
+    {
+        using index_type = std::remove_const_t< decltype( n_input_ports ) >;
+        for( index_type index( 0 ); index < n_input_ports; index++ )
+        {
+           /** add a port for each index var, all named "input_#" **/
+           input.addPort< T  >( std::to_string( index ) );
+        }
+        ofs = &stream;
+    }
+
+protected:
+    const std::size_t input_port_count    = 1;
 };
 
 template< typename T, char delim = '\0' > class print : public printabstract< T >
 {
 public:
-   print( ) : printabstract< T >()
-   {
-   }
-   
-   print( std::ostream &stream ) : printabstract< T >( stream )
-   {
-   }
-   
-   print( const print &other ) : print( *other.ofs )
-   {
-   }
+    print( const std::size_t n_input_ports = 1 ) : printabstract< T >( n_input_ports )
+    {
+    }
+    
+    print( std::ostream &stream, 
+           const std::size_t n_input_ports = 1 ) : printabstract< T >( stream, 
+                                                                       n_input_ports )
+    {
+    }
+    
+    print( const print &other ) : print( *other.ofs, other.input_port_count )
+    {
+    }
 
-   //FIXME - might need to synchronize streams for users
-   //design point
 
-   /** enable cloning **/
-   CLONE();
+    /** enable cloning **/
+    CLONE();
 
-   /** 
-    * run - implemented to take a single 
-    * input port, pop the itam and print it.
-    * the output isn't yet synchronized so if
-    * multiple things are printing to std::cout
-    * then there might be issues, otherwise
-    * this works well for debugging and basic 
-    * output.
-    * @return raft::kstatus
-    */
-   virtual raft::kstatus run()
-   {
-      std::lock_guard< std::mutex > lg( print< T, delim >::print_lock );
-      auto &input_port( (this)->input[ "in" ] );
-      auto &data( input_port.template peek< T >() );
-      *((this)->ofs) << data << delim;
-      input_port.unpeek();
-      input_port.recycle( 1 );
-      return( raft::proceed );
-   }
+    /** 
+     * run - implemented to take a single 
+     * input port, pop the itam and print it.
+     * the output isn't yet synchronized so if
+     * multiple things are printing to std::cout
+     * then there might be issues, otherwise
+     * this works well for debugging and basic 
+     * output.
+     * @return raft::kstatus
+     */
+    virtual raft::kstatus run()
+    {
+        for( auto &port : (this)->input )
+        {
+            if( port.size() > 0 )
+            {
+                const auto &data( port.template peek< T >() );
+                *((this)->ofs) << data << delim;
+                port.unpeek();
+                port.recycle( 1 );
+            }
+        }
+        return( raft::proceed );
+    }
 };
 
 
 template< typename T > class print< T, '\0' > : public printabstract< T >
 {
 public:
-   print( ) : printabstract< T >()
-   {
-   }
-   
-   print( std::ostream &stream ) : printabstract< T >( stream )
-   {
-   }
-   
-   //FIXME - might need to synchronize streams for users
-   //design point
-   print( const print &other ) : print( *other.ofs )
-   {
-   }
+    print( const std::size_t n_input_ports = 1 ) : printabstract< T >( n_input_ports )
+    {
+    }
+    
+    print( std::ostream &stream, 
+           const std::size_t n_input_ports = 1 ) : printabstract< T >( stream, 
+                                                                       n_input_ports )
+    {
+    }
+    
+    print( const print &other ) : print( *other.ofs, other.input_port_count )
+    {
+    }
 
-   CLONE();
+    CLONE();
                                  
 
-   /** 
-    * run - implemented to take a single 
-    * input port, pop the itam and print it.
-    * the output isn't yet synchronized so if
-    * multiple things are printing to std::cout
-    * then there might be issues, otherwise
-    * this works well for debugging and basic 
-    * output.
-    * @return raft::kstatus
-    */
-   virtual raft::kstatus run()
-   {
-      std::lock_guard< std::mutex > lg( print< T, '\0' >::print_lock );
-      auto &input_port( (this)->input[ "in" ] );
-      auto &data( input_port.template peek< T >() );
-      *((this)->ofs) << data;
-      input_port.unpeek();
-      input_port.recycle( 1 );
-      return( raft::proceed );
-   }
+    /** 
+     * run - implemented to take a single 
+     * input port, pop the itam and print it.
+     * the output isn't yet synchronized so if
+     * multiple things are printing to std::cout
+     * then there might be issues, otherwise
+     * this works well for debugging and basic 
+     * output.
+     * @return raft::kstatus
+     */
+    virtual raft::kstatus run()
+    {
+        for( auto &port : (this)->input )
+        {
+            if( port.size() > 0 )
+            {
+                const auto &data( port.template peek< T >() );
+                *((this)->ofs) << data;
+                port.unpeek();
+                port.recycle( 1 );
+            }
+        }
+        return( raft::proceed );
+    }
 };
 
 } /* end namespace raft */

--- a/src/kpair.cpp
+++ b/src/kpair.cpp
@@ -267,6 +267,21 @@ operator <= ( raft::kernel_wrapper &&w, kpair &b )
     return( *ptr );
 }
 
+
+kpair& 
+operator >= ( raft::kernel &a, raft::kernel &b )
+{
+    auto *ptr( new kpair( a, b, false, true ) );
+    return( *ptr );
+}
+
+kpair& 
+operator >= ( raft::kernel_wrapper &&a, raft::kernel_wrapper &&b )
+{
+    auto *ptr( new kpair( a, b, false, true ) );
+    return( *ptr );
+}
+
 kpair&
 operator >= ( kpair &a, raft::kernel_wrapper &&w )
 {

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -27,7 +27,8 @@ set( TESTAPPS allocate
      allocatePopInternalObject
      allocatePopExternal 
      parallelchain 
-     ksettest 
+     ksettest
+     multiPrint
      fixedMatchTest 
      splitchainRetStruct 
      staticContJoinRetStruct

--- a/testsuite/multiPrint.cpp
+++ b/testsuite/multiPrint.cpp
@@ -1,0 +1,97 @@
+/**
+ * random.cpp - 
+ * @author: Jonathan Beard
+ * @version: Mon Mar  2 14:00:14 2015
+ * 
+ * Copyright 2015 Jonathan Beard
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <raft>
+#include <raftrandom>
+#include <cstdint>
+#include <iostream>
+#include <raftio>
+#include "defs.hpp"
+#include <sstream>
+#include <iterator>
+
+#define STATICPORT 4
+
+template < class T > class sub : public raft::kernel
+{
+public:
+    sub() : raft::kernel() 
+    {
+        input.addPort< T >( "0" );
+        output.addPort< T >( "0" );
+    }
+
+    sub( const sub< T > &other ) : sub()
+    {
+        UNUSED( other );
+    };
+
+    virtual ~sub() = default;
+
+    CLONE();
+
+    virtual raft::kstatus run()
+    {
+        T a;
+        input[ "0" ].pop( a );
+        output[ "0" ].push( a - 10);
+        return( raft::proceed );
+    }
+};
+
+
+int
+main()
+{
+    using namespace raft;
+    using type_t = std::uint32_t;
+    using gen = random_variate< std::default_random_engine,
+                                std::uniform_int_distribution,
+                                type_t >;
+    using p_out = raft::print< type_t, ' ' >;
+    
+       
+    const static auto min( 0 );
+    const static auto max( 100 );
+    gen g( max /** count to generate **/, min, max );
+   
+    std::stringstream ss;
+
+    p_out print( ss, STATICPORT );
+    
+
+    raft::map m;
+    m += g >= print;
+    
+    m.exe();
+
+    const auto integer_count( 
+        std::distance(
+            std::istream_iterator<std::string>(ss), 
+            std::istream_iterator<std::string>()
+        )
+     );
+    std::cout << "counted \"" << integer_count << "\" integers\n";
+    if( integer_count == STATICPORT * max )
+    {
+        return( EXIT_SUCCESS );
+    }
+    return( EXIT_FAILURE );
+}

--- a/testsuite/vectorAlloc.cpp
+++ b/testsuite/vectorAlloc.cpp
@@ -28,8 +28,8 @@ using namespace raft;
 using type_t = std::vector< std::uint32_t >;
 using lambda_kernel = raft::lambdak< type_t >;
  
-/** hacky pring function **/
-std::ostream& operator << ( std::ostream &s, type_t &t )
+/** hacky print function **/
+std::ostream& operator << ( std::ostream &s, const type_t &t )
 {
     s << "{ ";
     for( const auto &x : t )


### PR DESCRIPTION
## Description

Existing print.tcc kernel provided did not have parameters to enable multiple input
ports. That was an oversight. To provide symmetry  with the filio functionality, we'll 
add this now to enable more logical application construction. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Runs locally on Windows
- [ ] Runs locally on Linux
- [x] Runs locally on OS X

### Details

Please list details of the configurations of above local tests, specifically 
relevant run details.

###
 
Please list test cases created to ensure your feature or addition
works. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
