### PR TITLE
updates to fileio, example cmake, and split off of chunkiterator and …

### DIFF
--- a/examples/general/readfile/CMakeLists.txt
+++ b/examples/general/readfile/CMakeLists.txt
@@ -1,4 +1,4 @@
-list( APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake )
+list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
 
 set( APP readtest)
 

--- a/raftinc/chunkiterator.tcc
+++ b/raftinc/chunkiterator.tcc
@@ -3,7 +3,7 @@
  * @author: Jonathan Beard
  * @version: Sun Oct  5 08:49:11 2014
  * 
- * Copyright 2014 Jonathan Beard
+ * Copyright 2020 Jonathan Beard
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,8 @@ namespace raft
 /** declare this guy **/
 template < std::size_t size > struct filechunk;
 
-template < std::size_t size > class chunk_iterator : public std::iterator< std::forward_iterator_tag, char >
+template < std::size_t size > class chunk_iterator : 
+    public std::iterator< std::forward_iterator_tag, char >
 {
 public:
    constexpr chunk_iterator( filechunk< size > * const chunk ) : chunk( chunk )

--- a/raftinc/filechunk.tcc
+++ b/raftinc/filechunk.tcc
@@ -1,0 +1,85 @@
+/**
+ * filechunk.tcc - 
+ * @author: Jonathan Beard
+ * @version: Sun Oct  4 08:29:07 2020
+ * 
+ * Copyright 2020 Jonathan Beard
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FILECHUNK_TCC
+#define FILECHUNK_TCC  1
+
+#include "chunkiterator.tcc"
+
+namespace raft
+{
+
+template < std::size_t size = 65536 > struct filechunk
+{
+   constexpr filechunk() = default;
+
+   filechunk( const filechunk< size > &other )
+   {
+      std::memcpy( buffer, other.buffer, other.length + 1 /** cp null term **/ );
+      start_position = other.start_position;
+      length = other.length;
+   }
+   
+   constexpr filechunk< size >& operator = ( const filechunk< size > &other )
+   {
+        //TODO - this will work for now, but there's better things
+        //that we can do. 
+        std::memcpy( buffer, other.buffer, other.length + 1 /** cp null term **/ );
+        start_position = other.start_position;
+        length = other.length;
+        return( *this );
+   }
+#pragma pack( push, 1 )
+   char           buffer[ size ];
+   std::size_t    start_position    = 0;
+   std::size_t    length            = 0;
+   std::uint64_t  index             = 0;
+#pragma pack( pop )
+
+   constexpr static std::size_t getChunkSize() noexcept
+   {
+      return( size );
+   }
+
+   friend std::ostream& operator << ( std::ostream &output, const filechunk< size > &c )
+   {
+      output << c.buffer;
+      return( output );
+   }
+
+   chunk_iterator< size > begin() noexcept
+   {
+      return( chunk_iterator< size >( this ) );
+   }
+
+   chunk_iterator< size > end() noexcept
+   {
+      return( chunk_iterator< size >( this, length ) );
+   }
+
+   inline char operator []( const std::size_t n )
+   {
+      assert( n >= 0  && n < size );
+      return( buffer[ n ] );
+   }
+};
+
+} //end namespace raft
+
+#endif /* END FILECHUNK_TCC */

--- a/raftinc/fileio.tcc
+++ b/raftinc/fileio.tcc
@@ -3,7 +3,7 @@
  * @author: Jonathan Beard
  * @version: Mon Sep 29 14:24:00 2014
  *
- * Copyright 2014 Jonathan Beard
+ * Copyright 2020 Jonathan Beard
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,77 +28,19 @@
 #include <cmath>
 #include <raft>
 #include <type_traits>
+#include "filechunk.tcc"
 #include "chunkiterator.tcc"
 
-
-/**
- * FIXME: needs to have to copy function implemenented
- * so that each port has the option of receiving copies
- * of the transfered data.
- */
 
 namespace raft{
 
 enum readertype : std::int8_t { chunk, fasta };
 
-template < std::size_t size = 65536 > struct filechunk
-{
-   constexpr filechunk() = default;
-
-   filechunk( const filechunk< size > &other )
-   {
-      std::memcpy( buffer, other.buffer, other.length + 1 /** cp null term **/ );
-      start_position = other.start_position;
-      length = other.length;
-   }
-   
-   constexpr filechunk< size >& operator = ( const filechunk< size > &other )
-   {
-        //TODO - this will work for now, but there's better things
-        //that we can do. 
-        std::memcpy( buffer, other.buffer, other.length + 1 /** cp null term **/ );
-        start_position = other.start_position;
-        length = other.length;
-        return( *this );
-   }
-#pragma pack( push, 1 )
-   char           buffer[ size ];
-   std::size_t    start_position    = 0;
-   std::size_t    length            = 0;
-   std::uint64_t  index             = 0;
-#pragma pack( pop )
-
-   constexpr static std::size_t getChunkSize() noexcept
-   {
-      return( size );
-   }
-
-   friend std::ostream& operator <<( std::ostream &output, filechunk< size > &c )
-   {
-      output << c.buffer;
-      return( output );
-   }
-
-   chunk_iterator< size > begin() noexcept
-   {
-      return( chunk_iterator< size >( this ) );
-   }
-
-   chunk_iterator< size > end() noexcept
-   {
-      return( chunk_iterator< size >( this, length ) );
-   }
-
-   inline char operator []( const std::size_t n )
-   {
-      assert( n >= 0  && n < size );
-      return( buffer[ n ] );
-   }
-};
 
 
-template < class chunktype = filechunk< 65536 >,
-           bool copy = false > class filereader : public raft::kernel
+template < class chunktype  = filechunk< 65536 >,
+           bool copy        = false > 
+                class filereader : public raft::kernel
 {
 public:
    filereader( const std::string inputfile,

--- a/raftio
+++ b/raftio
@@ -1,4 +1,6 @@
 /** io stuffs for raft **/
 
+#include "./raftinc/filechunk.tcc"
+#include "./raftinc/chunkiterator.tcc"
 #include "./raftinc/fileio.tcc"
 #include "./raftinc/print.tcc"


### PR DESCRIPTION
## Description

Fixes issue when compiling with ```-DBUILD_EXAMPLES=TRUE``` where stream 
operators were not recognized, the CMAKE build path was set incorrectly within 
the _filereader_ example, this is fixed. Also moved out the chunkiterator file into
its own header. Was initially thinking this was related to issue #139, however, might
not be the case. That being said, it could give a clue as to why #139 is there, potentially
the raft header files are not included correctly or in the right order, will add to that
issue. 

Fixes # (issue)

No issue request specifically. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Runs locally on Windows
- [x] Runs locally on Linux
- [x] Runs locally on OS X

### Details

Please list details of the configurations of above local tests, specifically 
relevant run details.

###
 
Please list test cases created to ensure your feature or addition
works. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
