### PR TITLE
Fix heap RingBuffer tight loop to always yield

### DIFF
--- a/raftinc/ringbufferheap.tcc
+++ b/raftinc/ringbufferheap.tcc
@@ -778,8 +778,8 @@ protected:
             {
                rd_stats  = 1;
             }
-            raft::yield();
          }
+         raft::yield();
       }
       auto * const buff_ptr( (this)->datamanager.get() );
       const std::size_t read_index( Pointer::val( buff_ptr->read_pt ) );


### PR DESCRIPTION
## Description

In the polling loop of `RingBufferBase::local_pop`, the code checks if the queue is resizing, and executes different blocks depending on the result. However, only the `true` case calls `raft::yield()`, meaning that non-resizing queues will be polled ad infinitum without yielding. When using QThreads to manage kernel execution, proper opportunities to `yield` are critical, and without such a call, valid programs can run indefinitely.

This might not fix all the issues presented in #146 (e.g. the crashes), but might be related to the hanging experienced.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested with a sample FDTD program consisting of 6 interdependent kernels. Prior to the fix, running with QThreads with fewer than 6 workers almost always hangs. After the fix, the program never hangs.

- [x] Runs locally on Linux

### Details

Please list details of the configurations of above local tests, specifically 
relevant run details.

Run on https://github.com/EmeraldShift/fdtd-rl with `QT=1`: `fdtd -q1 1 1 1 1`

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings
