### PR TITLE
StdAlloc should use INITIAL_ALLOC_SIZE

### DIFF
--- a/src/stdalloc.cpp
+++ b/src/stdalloc.cpp
@@ -44,30 +44,8 @@ stdalloc::run()
                           PortInfo &b,
                           void *data )
    {
-      (void) data;
-
-      assert( a.type == b.type );
-      /** assume everyone needs a heap for the moment to get working **/
-      auto &func_map( a.const_map[ Type::Heap ] );
-      FIFO *fifo( nullptr );
-      auto test_func( (*func_map)[ false ] );
-      /** check and see if a has a defined allocation **/
-      if( a.existing_buffer != nullptr )
-      {
-         fifo = test_func( a.nitems,
-                           a.start_index,
-                           a.existing_buffer );
-      }
-      else
-      {
-         /** check for pre-existing alloc size for test purposes **/
-         fifo = test_func( a.fixed_buffer_size != 0 ?
-                              a.fixed_buffer_size : 4    /** size **/,
-                           ALLOC_ALIGN_WIDTH             /** align **/,
-                           nullptr                       /** data struct **/);
-      }
-      assert( fifo != nullptr );
-      (this)->initialize( &a, &b, fifo );
+      /** same alloc for all, inherit from base alloc **/
+     (this)->allocate( a, b, data );
    };
    auto &container( (this)->source_kernels.acquire() );
    GraphTools::BFS( container, alloc_func );


### PR DESCRIPTION
## Description

StdAlloc Queues size were forced to 4 now they've are set to INITIAL_ALLOC_SIZE by default

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Runs locally on Linux passes all tests

### Details

There are no pertinent details

###
 
No test cases were created

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
