### PR TITLE
updates to fix pkg-config on global install

### DIFF
--- a/cmake/PkgConfigHelper.cmake
+++ b/cmake/PkgConfigHelper.cmake
@@ -1,0 +1,57 @@
+##
+# RULE #1, make ${project_name}.pc.in file with project name in lower case
+# RULE #2, you can set a custom name if you wish by using the PKG_CONFIG_IN var
+# RULE #3, refer to #1
+##
+
+string( TOLOWER ${PROJECT_NAME} PROJECT_NAME_LC )
+set( PC_FILE_NAME "${PROJECT_NAME_LC}.pc" )
+
+if( EXISTS "${PROJECT_SOURCE_DIR}/${PROJECT_NAME_LC}.pc.in" )
+    set( PKG_CONFIG_SOURCE "${PROJECT_SOURCE_DIR}/${PROJECT_NAME_LC}.pc.in" )
+    message( STATUS "Setting pkg-config source file as \"${PKG_CONFIG_SOURCE}\"" )
+else()
+
+    if( PKG_CONFIG_IN )
+        set( PKG_CONFIG_SOURCE ${PKG_CONFIG_IN} )
+        message( STATUS "Setting pkg-config source file as \"${PKG_CONFIG_SOURCE}\" based on config directive." )
+    else()
+        message( WARNING "No pkg-config input file specified, and none provided in source directory" )
+    endif()
+
+endif()
+
+
+if( NOT WIN32 )
+##
+# make and setup pkg-config
+##
+mark_as_advanced( PKG_CONFIG_PATHWAY )
+set( PKG_CONFIG_PATH "" CACHE STRING "Set the pkg-config path, othwerwise will figure out" )
+if( NOT PKG_CONFIG_PATH )
+execute_process( COMMAND  pkg-config --variable pc_path pkg-config 
+                 COMMAND  tr ':' '\n' 
+                 COMMAND  head -n 1
+                 OUTPUT_VARIABLE LOCAL_PKG_CONFIG_PATHWAY )
+string(REGEX REPLACE "\n$" "" LOCAL_PKG_CONFIG_PATHWAY "${LOCAL_PKG_CONFIG_PATHWAY}")
+set( PKG_CONFIG_PATH ${LOCAL_PKG_CONFIG_PATHWAY} )
+endif()
+
+string(REPLACE ":" ";" PREFIX_LIST "${CMAKE_SYSTEM_PREFIX_PATH}")
+list(FIND PREFIX_LIST ${CMAKE_INSTALL_PREFIX}  _index)
+
+if(${_index} GREATER 0)
+    file( MAKE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/pkgconfig ) 
+    set( PKG_CONFIG_PATH ${CMAKE_INSTALL_PREFIX}/pkgconfig )
+    message( WARNING "You should set PKG_CONFIG_PATH=${CMAKE_INSTALL_PREFIX}/pkgconfig/:$PKG_CONFIG_PATH when installing to non-standard prefix for pkg-config to work correctly!" )
+else()
+    message( STATUS "Setting PKG_CONFIG_PATH to: ${PKG_CONFIG_PATH}" )
+endif()
+
+
+##
+# actual install stuffs go here
+##
+configure_file( ${PKG_CONFIG_SOURCE} ${PC_FILE_NAME} @ONLY )
+install( FILES ${PROJECT_BINARY_DIR}/${PC_FILE_NAME} DESTINATION  ${PKG_CONFIG_PATH} )
+endif( NOT WIN32 )


### PR DESCRIPTION
## Description

CMakeLists.txt file had a reversion in the pkg-config detection code. Went ahead and wrote a standalone cmake helper to add generic pkg-config setup code. Tested locally on OS X and Linux with two differing versions of CMake. Installs correctly for both local and global builds. 

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Runs locally on Windows
- [ ] Runs locally on Linux
- [ ] Runs locally on OS X

### Details

Created new file which is PkgConfigHelper.cmake to take care of the cmake setup. 

###
 
Please list test cases created to ensure your feature or addition
works. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
