### PR TITLE
Fix race condition caused by OoO stores

### DIFF
--- a/raftinc/ringbufferheap.tcc
+++ b/raftinc/ringbufferheap.tcc
@@ -304,6 +304,9 @@ protected:
           (this)->producer_data.write_stats->bec.count++;
        }
       buff_ptr->signal[ write_index ]         = signal;
+#if defined(__aarch64__)
+      asm volatile( "dmb ishst" : : : "memory" ); /** memory write barrier **/
+#endif
        Pointer::inc( buff_ptr->write_pt );
 #if 0       
       if( signal == raft::quit )
@@ -740,6 +743,9 @@ protected:
           (this)->producer_data.write_stats->bec.count++;
        }
       buff_ptr->signal[ write_index ]         = signal;
+#if defined(__aarch64__)
+      asm volatile( "dmb ishst" : : : "memory" ); /** memory write barrier **/
+#endif
        Pointer::inc( buff_ptr->write_pt );
       (this)->datamanager.exitBuffer( dm::push );
    }
@@ -1205,6 +1211,9 @@ protected:
          (this)->producer_data.write_stats->bec.count++;
        }
       buff_ptr->signal[ write_index ]         = signal;
+#if defined(__aarch64__)
+      asm volatile( "dmb ishst" : : : "memory" ); /** memory write barrier **/
+#endif
        Pointer::inc( buff_ptr->write_pt );
 #if 0       
       if( signal == raft::quit )

--- a/raftinc/ringbuffershm.tcc
+++ b/raftinc/ringbuffershm.tcc
@@ -304,6 +304,9 @@ protected:
           (this)->producer_data.write_stats->bec.count++;
        }
       buff_ptr->signal[ write_index ]         = signal;
+#if defined(__aarch64__)
+      asm volatile( "dmb ishst" : : : "memory" ); /** memory write barrier **/
+#endif
        Pointer::inc( buff_ptr->write_pt );
       (this)->datamanager.exitBuffer( dm::push );
    }
@@ -734,6 +737,9 @@ protected:
           (this)->producer_data.write_stats->bec.count++;
        }
       buff_ptr->signal[ write_index ]         = signal;
+#if defined(__aarch64__)
+      asm volatile( "dmb ishst" : : : "memory" ); /** memory write barrier **/
+#endif
        Pointer::inc( buff_ptr->write_pt );
 #if 0
       if( signal == raft::quit )

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -50,6 +50,7 @@ set( TESTAPPS allocate
      nonTrivialAllocatorPopExternal
      vectorAlloc
      stringAlloc
+     reduction
      )
 else()
 set( TESTAPPS 

--- a/testsuite/reduction.cpp
+++ b/testsuite/reduction.cpp
@@ -1,0 +1,121 @@
+#include <raft>
+
+struct reduction_msg
+{
+    int *pcnt;
+    int cnt;
+};
+
+class reduce : public raft::parallel_k
+{
+public:
+    reduce( int ninputs ) : raft::parallel_k()
+    {
+        for( int i( 0 ); ninputs > i; ++i )
+        {
+            addPortTo< struct reduction_msg >( input );
+        }
+    }
+    virtual raft::kstatus run()
+    {
+        for( auto &port : input )
+        {
+            if( 0 < port.size() )
+            {
+                auto &msg( port.template peek< struct reduction_msg >() );
+                *( msg.pcnt ) += msg.cnt;
+                port.recycle( 1 );
+            }
+        }
+        return raft::proceed;
+    }
+};
+
+class count : public raft::kernel
+{
+public:
+    count( int *cnts ) : raft::kernel(), pcnts( cnts )
+    {
+        input.addPort< int >( "input" );
+        output.addPort< struct reduction_msg >( "output" );
+    }
+    count( const count &other ) : raft::kernel(), pcnts( other.pcnts )
+    {
+        input.addPort< int >( "input" );
+        output.addPort< struct reduction_msg >( "output" );
+    }
+    ~count() = default;
+    virtual raft::kstatus run()
+    {
+        int idx;
+        input["input"].pop< int >( idx );
+        while( idx ) {
+            output["output"].push< struct reduction_msg >(
+                    { &pcnts[ idx ], idx ^ 0x123 } );
+            idx >>= 1;
+        }
+        return raft::proceed;
+    }
+    CLONE(); // enable cloning
+private:
+    int *pcnts;
+};
+
+class workset : public raft::parallel_k
+{
+public:
+    workset( int noutputs, int m ) : raft::parallel_k(), idx_max( m )
+    {
+        for( int i( 0 ); noutputs > i; ++i )
+        {
+            addPortTo< int >( output );
+        }
+        idx = 0;
+    }
+    virtual raft::kstatus run()
+    {
+        for( auto &port : output )
+        {
+            if( port.space_avail() )
+            {
+                port.template push< int >( idx );
+                if( idx_max <= ++idx )
+                {
+                    return raft::stop;
+                }
+            }
+        }
+        return raft::proceed;
+    }
+private:
+    int idx_max, idx;
+};
+
+int main( int argc, char **argv )
+{
+   int arg_cnt( 1000 );
+   int arg_run( 60 );
+   if( argc >= 2 )
+   {
+      arg_cnt = atoi( argv[ 1 ] );
+   }
+   if( argc >= 3 )
+   {
+      arg_run = atoi( argv[ 2 ] );
+   }
+   int *cnts = new int[ arg_cnt ];
+
+   for( int i( 0 ); arg_run > i; ++i )
+   {
+       workset workset_k( 4, arg_cnt );
+       reduce reduce_k( 4 );
+       count count_k( cnts );
+
+       raft::map m;
+       m += workset_k <= count_k >= reduce_k;
+
+       m.exe();
+   }
+
+   return( EXIT_SUCCESS );
+}


### PR DESCRIPTION
## Description

The message queue potentially has the pointer incremented before the data is actually stored into buffer (violate program order, but it happens on Ampere processor).
When there are pointers passed through the message queue, this bug could trigger segmentation fault, as demonstrated by the new test case `reduction`.

## Type of change

Inserting a write memory barrier before the write pointer increment addresses the issue.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Runs locally on Windows
- [x] Runs locally on Linux
- [ ] Runs locally on OS X

### Details

On an Ampere server, Linux 5.4.0-99-generic.
The command `make test` tests the new test case `reduction` as well.
If the newly-added memory barriers are removed, `reduction` would fail with SegFault.

###
 
All existing tests and the new one `reduction`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
