### PR TITLE
Fix: prevent meaningless scheduling iterations of simpleschedule with penalty.

### DIFF
--- a/src/schedule.cpp
+++ b/src/schedule.cpp
@@ -213,7 +213,6 @@ bool
 Schedule::kernelRun( raft::kernel * const kernel,
                      volatile bool       &finished )
 {
-
    if( kernelHasInputData( kernel ) )
    {
       const auto sig_status( kernel->run() );
@@ -222,6 +221,11 @@ Schedule::kernelRun( raft::kernel * const kernel,
          invalidateOutputPorts( kernel );
          finished = true;
       }
+   }
+   else
+   {
+     // a kernel is scheduled, but kernel->run() is not executed.
+     return false;
    }
    /**
     * must recheck data items again after port valid check, there could

--- a/src/simpleschedule.cpp
+++ b/src/simpleschedule.cpp
@@ -168,8 +168,14 @@ simple_schedule::simple_run( void * data )
    }
    while( ! *(thread_d->finished) )
    {
-      Schedule::kernelRun( thread_d->k, *(thread_d->finished) );
+      bool validScheduling = Schedule::kernelRun( thread_d->k, *(thread_d->finished) );
       //takes care of peekset clearing too
       Schedule::fifo_gc( &in, &out, &peekset );
+
+      if(validScheduling == false)
+      {
+        std::chrono::milliseconds dura( 5 );
+        std::this_thread::sleep_for( dura );
+      }
    }
 }


### PR DESCRIPTION
## Description

**TL;DR - Too simple simplescheduler**

The current simplescheduler schedules the kernel as fast as the CPU runs. When the stream from a source kernel is generated at very high frequency, the current simplescheduler would be fine. However, when the upstream kernel runs at a lower frequency, scheduling kernels dominates the CPU core usage while the scheduled kernel's run() is not executed.

The demonstration of this bug is done by the two cases of poc.cpp. The demonstration codes of modified poc.cpp are [here](https://gist.github.com/jheo4/be4f60144f0dc3ec1b90f250cd7cfb23). 

- Case1: I made **kernel A** sleep 1 second and measured the energy consumption of CPUs. The result is below.
```
 Performance counter stats for 'system wide':
            346.47 Joules power/energy-cores/                                         
      10.008960046 seconds time elapsed
```
- Case2: I made **kernel C** sleep 1 second and measured the energy consumption of CPUs. The result is below.
```
 Performance counter stats for 'system wide':
            132.33 Joules power/energy-cores/                                         
      10.008950988 seconds time elapsed
```
While these two cases did almost the same things, the CPU usages were very different and it caused the different energy consumptions also.

To prevent this inefficiency, I checked whether the scheduled kernel run() is really executed, and if not, penalized the next scheduling with 5 ms of sleeping. It is quite hacky and simple, but I think it would be fine with the "simple" scheduler.
For further schedulers, a more fancy backoff mechanism can be applied such as exponential backoff which was adopted by the network community in the past.

With my small modification, I re-tested the above cases, and th results are followings:

- Case1: making kernel A sleep 1 second, but this result is with my commit.
```
 Performance counter stats for 'system wide':
            138.02 Joules power/energy-cores/                                         
      10.012098173 seconds time elapsed
```
- Case2: making kernel C sleep 1 second, but this result is with my commit.
```
 Performance counter stats for 'system wide':
            138.48 Joules power/energy-cores/   
      10.013501176 seconds time elapsed
```

Fixes #163 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Runs locally on Windows
- [x] Runs locally on Linux
- [ ] Runs locally on OS X

### Details

I tested my commit on Ubuntu 20.04 and 22.04.

###
 
Please list test cases created to ensure your feature or addition
works. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
